### PR TITLE
Correct version of controller pod

### DIFF
--- a/helm/jetstream-controller/values.yaml
+++ b/helm/jetstream-controller/values.yaml
@@ -1,3 +1,3 @@
 image:
   name: connecteverything/jetstream-controller
-  version: 1.0.0
+  version: 0.1.0


### PR DESCRIPTION
I understand this is still really early days, but the Helm installation didn't work. I just tried running the installation but the controller went to ImagePullBackOff. Looking at [Docker Hub](https://hub.docker.com/r/connecteverything/jetstream-controller/tags), I could find 0.1.0 available

```
$ helm install nack-jetstream-controller helm/jetstream-controller
```

```bash
$ kubectl describe pod jetstream-controller-pod

...

Events:
  Type     Reason     Age                From                       Message
  ----     ------     ----               ----                       -------
  Normal   Scheduled  30s                default-scheduler          Successfully assigned default/jetstream-controller-pod to kind-nack-worker
  Normal   BackOff    26s                kubelet, kind-nack-worker  Back-off pulling image "connecteverything/jetstream-controller:1.0.0"
  Warning  Failed     26s                kubelet, kind-nack-worker  Error: ImagePullBackOff
  Normal   Pulling    16s (x2 over 30s)  kubelet, kind-nack-worker  Pulling image "connecteverything/jetstream-controller:1.0.0"
  Warning  Failed     14s (x2 over 27s)  kubelet, kind-nack-worker  Failed to pull image "connecteverything/jetstream-controller:1.0.0": rpc error: code = NotFound desc = failed to pull and unpack image "docker.io/connecteverything/jetstream-controller:1.0.0": failed to resolve reference "docker.io/connecteverything/jetstream-controller:1.0.0": docker.io/connecteverything/jetstream-controller:1.0.0: not found
  Warning  Failed     14s (x2 over 27s)  kubelet, kind-nack-worker  Error: ErrImagePull
```

Also, even with v0.1.0, it went straight away to Error with "NATS Server URL is required". I thought the Helm install or controller would create a new NATS server instance, but it doesn't seem to be the case. I can understand how controller fails to apply JetStream configurations without NATS server instance, but controller not coming up seems to be too much...? I'm curious to understand the general direction of how much NACK is going to solve (NATS server creation can be bundled with jetstream-controller, or there would be separate controller for NATS server, etc.), and also keen to contribute if anything needs a hand! 👐