### PR TITLE
Add servers, creds and nkey options to nack

### DIFF
--- a/deploy/crds.yml
+++ b/deploy/crds.yml
@@ -29,6 +29,14 @@ spec:
                 items:
                   type: string
                 default: []
+              creds:
+                description: NATS user credentials for connecting to servers. Please make sure your controller has mounted the cerds on its path.
+                type: string
+                default: ''
+              nkey:
+                description: NATS user NKey for connecting to servers.
+                type: string
+                default: ''
               name:
                 description: A unique name for the Stream.
                 type: string
@@ -163,6 +171,14 @@ spec:
                 items:
                   type: string
                 default: []
+              creds:
+                description: NATS user credentials for connecting to servers. Please make sure your controller has mounted the cerds on its path.
+                type: string
+                default: ''
+              nkey:
+                description: NATS user NKey for connecting to servers.
+                type: string
+                default: ''
               streamName:
                 description: The name of the Stream to create the Consumer in.
                 type: string
@@ -293,6 +309,14 @@ spec:
                 items:
                   type: string
                 default: []
+              creds:
+                description: NATS user credentials for connecting to servers. Please make sure your controller has mounted the cerds on its path.
+                type: string
+                default: ''
+              nkey:
+                description: NATS user NKey for connecting to servers.
+                type: string
+                default: ''
               name:
                 description: A unique name for the Stream Template.
                 type: string

--- a/pkg/jetstream/apis/jetstream/v1beta1/consumertypes.go
+++ b/pkg/jetstream/apis/jetstream/v1beta1/consumertypes.go
@@ -23,6 +23,8 @@ func (c *Consumer) GetSpec() interface{} {
 // ConsumerSpec is the spec for a Consumer resource
 type ConsumerSpec struct {
 	Servers        []string `json:"servers"`
+	Creds          string   `json:"creds"`
+	Nkey           string   `json:"nkey"`
 	StreamName     string   `json:"streamName"`
 	DeliverPolicy  string   `json:"deliverPolicy"`
 	OptStartSeq    int      `json:"optStartSeq"`

--- a/pkg/jetstream/apis/jetstream/v1beta1/streamtypes.go
+++ b/pkg/jetstream/apis/jetstream/v1beta1/streamtypes.go
@@ -23,6 +23,8 @@ func (s *Stream) GetSpec() interface{} {
 // StreamSpec is the spec for a Stream resource
 type StreamSpec struct {
 	Servers         []string `json:"servers"`
+	Creds           string   `json:"creds"`
+	Nkey            string   `json:"nkey"`
 	Name            string   `json:"name"`
 	Subjects        []string `json:"subjects"`
 	Retention       string   `json:"retention"`


### PR DESCRIPTION
Hi, this pr is for #21 .

NATS is a so amazing project! So I want to do something to make it better. I don’t know if my understanding is correct, so I drew a picture to express my thoughts:

![image](https://user-images.githubusercontent.com/26180598/109942676-63f64f00-7d0f-11eb-9d37-676ee8fad3a7.png)

What's different:

Add a `servers` option for Stream/StreamTemplate and Consumer crd. It's optional and will be an empty array by default. When you set this option, the controller will create a new nats connection and then initialize a jsm client to create Stream/StreamTemplate or Consumer.

```bash
$ kubectl logs jetstream-controller-65d5898bb7-9r4rb -f
# without servers option
I0304 08:04:14.386280       1 event.go:282] Event(v1.ObjectReference{Kind:"Stream", Namespace:"default", Name:"testnoserver00", UID:"e48551cf-6101-4e1f-813a-637b4d711605", APIVersion:"jetstream.nats.io/v1beta1", ResourceVersion:"21314662", FieldPath:""}): type: 'Normal' reason: 'Creating' Creating stream "testnoserver00"
I0304 08:04:14.474232       1 event.go:282] Event(v1.ObjectReference{Kind:"Stream", Namespace:"default", Name:"testnoserver00", UID:"e48551cf-6101-4e1f-813a-637b4d711605", APIVersion:"jetstream.nats.io/v1beta1", ResourceVersion:"21314663", FieldPath:""}): type: 'Normal' reason: 'Created' Created stream "testnoserver00"

I0304 08:07:27.259351       1 event.go:282] Event(v1.ObjectReference{Kind:"Consumer", Namespace:"default", Name:"testnoserver00", UID:"1cd08dae-bb7c-41aa-863d-6306a352bcfd", APIVersion:"jetstream.nats.io/v1beta1", ResourceVersion:"21315279", FieldPath:""}): type: 'Normal' reason: 'Creating' Creating consumer "testnoserver00" on stream "testnoserver00"
I0304 08:07:27.340657       1 event.go:282] Event(v1.ObjectReference{Kind:"Consumer", Namespace:"default", Name:"testnoserver00", UID:"1cd08dae-bb7c-41aa-863d-6306a352bcfd", APIVersion:"jetstream.nats.io/v1beta1", ResourceVersion:"21315280", FieldPath:""}): type: 'Normal' reason: 'Created' Created consumer "testnoserver00" on stream "testnoserver00"

# with servers option
I0304 08:13:37.694530       1 event.go:282] Event(v1.ObjectReference{Kind:"Stream", Namespace:"default", Name:"testserver00", UID:"3629f0b3-522d-4286-99aa-71dbe8c9fc8e", APIVersion:"jetstream.nats.io/v1beta1", ResourceVersion:"21316506", FieldPath:""}): type: 'Normal' reason: 'Creating' Creating stream "testserver00"
I0304 08:13:37.696927       1 event.go:282] Event(v1.ObjectReference{Kind:"Stream", Namespace:"default", Name:"testserver00", UID:"3629f0b3-522d-4286-99aa-71dbe8c9fc8e", APIVersion:"jetstream.nats.io/v1beta1", ResourceVersion:"21316506", FieldPath:""}): type: 'Normal' reason: 'Connecting' Connecting to new nats-servers
I0304 08:13:37.958991       1 event.go:282] Event(v1.ObjectReference{Kind:"Stream", Namespace:"default", Name:"testserver00", UID:"3629f0b3-522d-4286-99aa-71dbe8c9fc8e", APIVersion:"jetstream.nats.io/v1beta1", ResourceVersion:"21316507", FieldPath:""}): type: 'Normal' reason: 'Created' Created stream "testserver00"

I0304 08:17:10.385516       1 event.go:282] Event(v1.ObjectReference{Kind:"Consumer", Namespace:"default", Name:"testserver00", UID:"1c5afc4d-703f-4cdb-aaba-cfc243c23f5d", APIVersion:"jetstream.nats.io/v1beta1", ResourceVersion:"21317215", FieldPath:""}): type: 'Normal' reason: 'Creating' Creating consumer "testserver00" on stream "testserver00"
I0304 08:17:10.391586       1 event.go:282] Event(v1.ObjectReference{Kind:"Consumer", Namespace:"default", Name:"testserver00", UID:"1c5afc4d-703f-4cdb-aaba-cfc243c23f5d", APIVersion:"jetstream.nats.io/v1beta1", ResourceVersion:"21317215", FieldPath:""}): type: 'Normal' reason: 'Connecting' Connecting to new nats-servers
I0304 08:17:10.843949       1 event.go:282] Event(v1.ObjectReference{Kind:"Consumer", Namespace:"default", Name:"testserver00", UID:"1c5afc4d-703f-4cdb-aaba-cfc243c23f5d", APIVersion:"jetstream.nats.io/v1beta1", ResourceVersion:"21317216", FieldPath:""}): type: 'Normal' reason: 'Created' Created consumer "testserver00" on stream "testserver00"
```

