### PR TITLE
Swap the values of file and memory storage options

### DIFF
--- a/controllers/jetstream/stream.go
+++ b/controllers/jetstream/stream.go
@@ -181,9 +181,9 @@ func createStream(ctx context.Context, c jsmClient, spec apis.StreamSpec) (err e
 
 	switch spec.Storage {
 	case "file":
-		opts = append(opts, jsm.MemoryStorage())
-	case "memory":
 		opts = append(opts, jsm.FileStorage())
+	case "memory":
+		opts = append(opts, jsm.MemoryStorage())
 	}
 
 	switch spec.Discard {


### PR DESCRIPTION
Currently, we have `spec.Storage("file")` mapped to `jsm.MemoryStorage` and
`spec.Storage("memory")` mapped to `jsm.FileStorage`.  These should be swapped.

Fix #24