### PR TITLE
deploy: eliminate namespace from Cluster* RBAC

### DIFF
--- a/deploy/rbac.yml
+++ b/deploy/rbac.yml
@@ -9,7 +9,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: jetstream-controller-cluster-role
-  namespace: default
 rules:
 - apiGroups:
   - ''
@@ -41,7 +40,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: jetstream-controller-cluster-role-binding
-  namespace: default
 subjects:
 - kind: ServiceAccount
   name: jetstream-controller


### PR DESCRIPTION
ClusterRole and ClusterRoleBinding are not namespaced objects in Kubernetes.
This commit eliminates the `namespace` field from the metadata of the
cluster-wide resources in the deploy directory.