### PR TITLE
Only send reload signal when necessary

### DIFF
--- a/pkg/natsreloader/natsreloadertest/natsreloader_test.go
+++ b/pkg/natsreloader/natsreloadertest/natsreloader_test.go
@@ -3,7 +3,6 @@ package natsreloadertest
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"sync"
@@ -22,7 +21,7 @@ someOtherThing = "bar"
 func TestReloader(t *testing.T) {
 	// Setup a pidfile that points to us
 	pid := os.Getpid()
-	pidfile, err := ioutil.TempFile(os.TempDir(), "nats-pid-")
+	pidfile, err := os.CreateTemp(os.TempDir(), "nats-pid-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -41,7 +40,7 @@ func TestReloader(t *testing.T) {
 
 	var configFiles []*os.File
 	for i := 0; i < 2; i++ {
-		configFile, err := ioutil.TempFile(os.TempDir(), "nats-conf-")
+		configFile, err := os.CreateTemp(os.TempDir(), "nats-conf-")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -94,6 +93,17 @@ func TestReloader(t *testing.T) {
 				time.Sleep(10 * time.Millisecond)
 			}
 		}
+
+		// Create some random file in the same directory, shouldn't trigger an
+		// additional server signal.
+		configFile, err := os.CreateTemp(os.TempDir(), "foo")
+		if err != nil {
+			t.Log(err)
+			return
+		}
+		defer os.Remove(configFile.Name())
+		time.Sleep(100 * time.Millisecond)
+
 		cancel()
 	}()
 


### PR DESCRIPTION
Currently, we send multiple reload signals to the NATS server when we detect any file changes within a watched directory. This causes unnecessary logging and reloading.

This change only sends a signal if a file we're interested in has changed. It ignores other file changes within the same directory. In addition, we no longer log for every event, of which there can be many, not all of them useful.

Here is what the Kubernetes logs look like after changing the NATS configmap one time.

```
$ kubectl logs -f nats-0 reloader
2021/11/03 21:51:53 Starting NATS Server Reloader v1.2.4
2021/11/03 21:51:53 Live, ready to kick pid 7 (live, from 7 spec) based on any of 1 files
2021/11/03 21:53:09 changed config; file="/etc/nats-config/nats.conf" existing=true total-files=1
2021/11/03 21:53:09 Sending signal to server to reload configuration due to: /etc/nats-config/..2021_11_03_21_53_09.444687858
```

Kubernetes note: In Kubernetes, files don't seem to get updated. Rather, they're deleted, recreated, and then resymlinked to the given path.