### PR TITLE
fix typos in example manifests

### DIFF
--- a/examples/secure/nack-b-client-tls.yaml
+++ b/examples/secure/nack-b-client-tls.yaml
@@ -7,7 +7,7 @@ spec:
   secretName: nack-b-tls
   duration: 2160h # 90 days
   renewBefore: 240h # 10 days
-  issuerRef:\
+  issuerRef:
     name: nats-ca
     kind: Issuer
   usages:

--- a/examples/secure/nats-client-box.yaml
+++ b/examples/secure/nats-client-box.yaml
@@ -27,8 +27,7 @@ spec:
       - name: nats-box
         image: natsio/nats-box:0.6.0
         imagePullPolicy: IfNotPresent
-        resources:
-          null
+        resources: {}
         env:
         - name: NATS_URL
           value: nats


### PR DESCRIPTION
* there was a trailing slash in the Certificate object from examples