### PR TITLE
Add resource cleanup loop

### DIFF
--- a/cmd/jetstream-controller/main.go
+++ b/cmd/jetstream-controller/main.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -58,6 +59,7 @@ func run() error {
 	ca := flag.String("tlsca", "", "NATS TLS certificate authority chain")
 	server := flag.String("s", "", "NATS Server URL")
 	crdConnect := flag.Bool("crd-connect", false, "If true, then NATS connections will be made from CRD config, not global config")
+	cleanupPeriod := flag.Duration("cleanup-period", 30*time.Second, "Period to run object cleanup")
 	flag.Parse()
 
 	if *version {
@@ -112,6 +114,7 @@ func run() error {
 		JetstreamIface:  jc,
 		Namespace:       *namespace,
 		CRDConnect:      *crdConnect,
+		CleanupPeriod:   *cleanupPeriod,
 	})
 
 	klog.Infof("Starting %s v%s...", os.Args[0], Version)

--- a/controllers/jetstream/consumer.go
+++ b/controllers/jetstream/consumer.go
@@ -28,12 +28,6 @@ func (c *Controller) runConsumerQueue() {
 }
 
 func (c *Controller) processConsumer(ns, name string, jsmc jsmClient) (err error) {
-	defer func() {
-		if err != nil {
-			err = fmt.Errorf("failed to process consumer: %w", err)
-		}
-	}()
-
 	cns, err := c.cnsLister.Consumers(ns).Get(name)
 	if err != nil && k8serrors.IsNotFound(err) {
 		return nil
@@ -41,6 +35,17 @@ func (c *Controller) processConsumer(ns, name string, jsmc jsmClient) (err error
 		return err
 	}
 
+	return c.processConsumerObject(cns, jsmc)
+}
+
+func (c *Controller) processConsumerObject(cns *apis.Consumer, jsmc jsmClient) (err error) {
+	defer func() {
+		if err != nil {
+			err = fmt.Errorf("failed to process consumer: %w", err)
+		}
+	}()
+
+	ns := cns.Namespace
 	spec := cns.Spec
 	ifc := c.ji.Consumers(ns)
 

--- a/controllers/jetstream/stream.go
+++ b/controllers/jetstream/stream.go
@@ -40,12 +40,6 @@ func (c *Controller) runStreamQueue() {
 }
 
 func (c *Controller) processStream(ns, name string, jsmc jsmClient) (err error) {
-	defer func() {
-		if err != nil {
-			err = fmt.Errorf("failed to process stream: %w", err)
-		}
-	}()
-
 	str, err := c.strLister.Streams(ns).Get(name)
 	if err != nil && k8serrors.IsNotFound(err) {
 		return nil
@@ -53,8 +47,19 @@ func (c *Controller) processStream(ns, name string, jsmc jsmClient) (err error) 
 		return err
 	}
 
+	return c.processStreamObject(str, jsmc)
+}
+
+func (c *Controller) processStreamObject(str *apis.Stream, jsmc jsmClient) (err error) {
+	defer func() {
+		if err != nil {
+			err = fmt.Errorf("failed to process stream: %w", err)
+		}
+	}()
+
 	spec := str.Spec
 	ifc := c.ji.Streams(str.Namespace)
+	ns := str.Namespace
 
 	var (
 		remoteClientCert string


### PR DESCRIPTION
With finalizers gone, the Kubernetes Informers no longer send us an event when a resource is deleted. The resource just gets deleted. This is good because this avoids potential cluster lockups. However, this means we're in charge of resource cleanup now. Currently, streams and consumers are not deleted from JetStream when a user deletes a Stream or Consumer CRD.

This change adds a cleanup loop that periodically checks for deleted CRDs and deletes their corresponding JetStream stream or consumer.

I tested this with the old single server connection mode as well as the newer multi-server account mode.