### PR TITLE
Fix YAML maxBytes not being set on Stream

### DIFF
--- a/controllers/jetstream/stream.go
+++ b/controllers/jetstream/stream.go
@@ -255,6 +255,7 @@ func createStream(ctx context.Context, c jsmClient, spec apis.StreamSpec) (err e
 		jsm.Replicas(spec.Replicas),
 		jsm.DuplicateWindow(duplicates),
 		jsm.MaxAge(maxAge),
+		jsm.MaxBytes(int64(spec.MaxBytes)),
 	}
 
 	switch spec.Retention {


### PR DESCRIPTION
Currently, we accept maxBytes in the Stream YAML. However, we're not
actually passing this value to the client. This leads to a Stream being
created without maxBytes set.

This change passes maxBytes to the client so Streams get correctly
created.

Resolves https://github.com/nats-io/nack/issues/40 to unblock folks.