### PR TITLE
doc: fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Now install with Helm:
 ```
 helm repo add nats https://nats-io.github.io/k8s/helm/charts/
 helm install nats nats/nats --set=nats.jetstream.enabled=true
-helm install nack nats/nack
+helm install nack nats/nack --set jetstream.nats.url=nats://nats:4222
 ```
 
 #### Creating Streams and Consumers


### PR DESCRIPTION
Without this fix in docs I get this error when I try to create a stream using the operator:

```
❯ k logs nack-5b6b84ff7b-xntgw
I0413 09:31:23.429117       1 main.go:120] Starting /jetstream-controller v0.6.1...
E0413 09:31:23.533641       1 controller.go:416] failed to process stream: failed to connect to nats-servers(): nats: no servers available for connection
E0413 09:31:23.536061       1 controller.go:416] failed to process consumer: failed to connect to leaf nats(): nats: no servers available for connection
E0413 09:31:23.542344       1 controller.go:416] failed to process stream: failed to connect to nats-servers(): nats: no servers available for connection
```