### PR TITLE
Bump nats-boot-config base Alpine to 3.15 to address vulnerabilities

### DIFF
--- a/docker/nats-boot-config/Dockerfile
+++ b/docker/nats-boot-config/Dockerfile
@@ -7,7 +7,7 @@ RUN VERSION=$VERSION make nats-boot-config.docker
 FROM alpine:latest as osdeps
 RUN apk add --no-cache ca-certificates
 
-FROM alpine:3.8
+FROM alpine:3.15
 COPY --from=build /go/src/nack/nats-boot-config.docker /usr/local/bin/nats-boot-config
 COPY --from=osdeps /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 RUN ln -s /usr/local/bin/nats-boot-config /usr/local/bin/nats-pod-bootconfig


### PR DESCRIPTION
This is the same version used by nats-server-config-reloader.

This change addresses over a dozen critical and high vulnerabilities. Please merge and release as soon as possible. 