### PR TITLE
Allow connecting to account servers without TLS

### DIFF
--- a/controllers/jetstream/consumer.go
+++ b/controllers/jetstream/consumer.go
@@ -62,6 +62,8 @@ func (c *Controller) processConsumerObject(cns *apis.Consumer, jsmc jsmClient) (
 			return err
 		}
 
+		accServers = acc.Spec.Servers
+
 		// Lookup the TLS secrets
 		if acc.Spec.TLS != nil && acc.Spec.TLS.Secret != nil {
 			secretName := acc.Spec.TLS.Secret.Name
@@ -79,7 +81,6 @@ func (c *Controller) processConsumerObject(cns *apis.Consumer, jsmc jsmClient) (
 			remoteClientCert = filepath.Join(accDir, acc.Spec.TLS.ClientCert)
 			remoteClientKey = filepath.Join(accDir, acc.Spec.TLS.ClientKey)
 			remoteRootCA = filepath.Join(accDir, acc.Spec.TLS.RootCAs)
-			accServers = acc.Spec.Servers
 
 			for k, v := range secret.Data {
 				if err := os.WriteFile(filepath.Join(accDir, k), v, 0644); err != nil {

--- a/controllers/jetstream/stream.go
+++ b/controllers/jetstream/stream.go
@@ -74,6 +74,8 @@ func (c *Controller) processStreamObject(str *apis.Stream, jsmc jsmClient) (err 
 			return err
 		}
 
+		accServers = acc.Spec.Servers
+
 		// Lookup the TLS secrets
 		if acc.Spec.TLS != nil && acc.Spec.TLS.Secret != nil {
 			secretName := acc.Spec.TLS.Secret.Name
@@ -91,7 +93,6 @@ func (c *Controller) processStreamObject(str *apis.Stream, jsmc jsmClient) (err 
 			remoteClientCert = filepath.Join(accDir, acc.Spec.TLS.ClientCert)
 			remoteClientKey = filepath.Join(accDir, acc.Spec.TLS.ClientKey)
 			remoteRootCA = filepath.Join(accDir, acc.Spec.TLS.RootCAs)
-			accServers = acc.Spec.Servers
 
 			for k, v := range secret.Data {
 				if err := os.WriteFile(filepath.Join(accDir, k), v, 0644); err != nil {


### PR DESCRIPTION
Currently, we only read the server URLs in an Account CRD if TLS is configured. This change makes it so that we always read the account server URLs.

It should allow something like this to work.

```yaml
---
apiVersion: jetstream.nats.io/v1beta2
kind: Account
metadata:
  name: a-app
spec:
  name: a-app
  servers:
  - nats://a-app.test.tech:@nats.default.svc
```