### PR TITLE
Exposing `Republish` field for streams CRD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 /nats-boot-config
 /nats-boot-config.docker
 /tools
+/.idea

--- a/controllers/jetstream/stream.go
+++ b/controllers/jetstream/stream.go
@@ -335,6 +335,13 @@ func createStream(ctx context.Context, c jsmClient, spec apis.StreamSpec) (err e
 		return nil
 	})
 
+	if spec.Republish != nil {
+		opts = append(opts, jsm.Republish(&jsmapi.SubjectMapping{
+			Source:      spec.Republish.Source,
+			Destination: spec.Republish.Destination,
+		}))
+	}
+
 	_, err = c.NewStream(ctx, spec.Name, opts)
 	return err
 }

--- a/deploy/crds.yml
+++ b/deploy/crds.yml
@@ -179,6 +179,16 @@ spec:
                 description: Name of the account to which the Stream belongs.
                 type: string
                 pattern: '^[^.*>]*$'
+              republish:
+                description: Republish configuration of the stream.
+                type: object
+                properties:
+                  destination:
+                    type: string
+                    description: Messages will be additionally published to that subject.
+                  source:
+                    type: string
+                    description: Messages will be published from that subject to the destination subject.
           status:
             type: object
             properties:

--- a/pkg/jetstream/apis/jetstream/v1beta2/streamtypes.go
+++ b/pkg/jetstream/apis/jetstream/v1beta2/streamtypes.go
@@ -22,29 +22,30 @@ func (s *Stream) GetSpec() interface{} {
 
 // StreamSpec is the spec for a Stream resource
 type StreamSpec struct {
-	Account           string           `json:"account"`
-	Creds             string           `json:"creds"`
-	Description       string           `json:"description"`
-	Discard           string           `json:"discard"`
-	DuplicateWindow   string           `json:"duplicateWindow"`
-	MaxAge            string           `json:"maxAge"`
-	MaxBytes          int              `json:"maxBytes"`
-	MaxConsumers      int              `json:"maxConsumers"`
-	MaxMsgs           int              `json:"maxMsgs"`
-	MaxMsgSize        int              `json:"maxMsgSize"`
-	MaxMsgsPerSubject int              `json:"maxMsgsPerSubject"`
-	Mirror            *StreamSource    `json:"mirror"`
-	Name              string           `json:"name"`
-	Nkey              string           `json:"nkey"`
-	NoAck             bool             `json:"noAck"`
-	Placement         *StreamPlacement `json:"placement"`
-	Replicas          int              `json:"replicas"`
-	Retention         string           `json:"retention"`
-	Servers           []string         `json:"servers"`
-	Sources           []*StreamSource  `json:"sources"`
-	Storage           string           `json:"storage"`
-	Subjects          []string         `json:"subjects"`
-	TLS               TLS              `json:"tls"`
+	Account           string                `json:"account"`
+	Creds             string                `json:"creds"`
+	Description       string                `json:"description"`
+	Discard           string                `json:"discard"`
+	DuplicateWindow   string                `json:"duplicateWindow"`
+	MaxAge            string                `json:"maxAge"`
+	MaxBytes          int                   `json:"maxBytes"`
+	MaxConsumers      int                   `json:"maxConsumers"`
+	MaxMsgs           int                   `json:"maxMsgs"`
+	MaxMsgSize        int                   `json:"maxMsgSize"`
+	MaxMsgsPerSubject int                   `json:"maxMsgsPerSubject"`
+	Mirror            *StreamSource         `json:"mirror"`
+	Name              string                `json:"name"`
+	Nkey              string                `json:"nkey"`
+	NoAck             bool                  `json:"noAck"`
+	Placement         *StreamPlacement      `json:"placement"`
+	Replicas          int                   `json:"replicas"`
+	Republish         *StreamSubjectMapping `json:"republish"`
+	Retention         string                `json:"retention"`
+	Servers           []string              `json:"servers"`
+	Sources           []*StreamSource       `json:"sources"`
+	Storage           string                `json:"storage"`
+	Subjects          []string              `json:"subjects"`
+	TLS               TLS                   `json:"tls"`
 }
 
 type StreamPlacement struct {
@@ -60,6 +61,11 @@ type StreamSource struct {
 
 	ExternalAPIPrefix     string `json:"externalApiPrefix"`
 	ExternalDeliverPrefix string `json:"externalDeliverPrefix"`
+}
+
+type StreamSubjectMapping struct {
+	Source      string `json:"source"`
+	Destination string `json:"destination"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
We noticed that there is no possibility to configure the `Republish` option for the stream through CRD's. The PR is exposing that field and setting it up when creating a stream.

Co-authored-by: Lesley Funwie <lesley.funwie@form3.tech>
Co-authored-by: Joseph Woodward <joseph.woodward@form3.tech>