### PR TITLE
Add stream mirror field on updates

### DIFF
--- a/controllers/jetstream/stream.go
+++ b/controllers/jetstream/stream.go
@@ -394,6 +394,14 @@ func updateStream(ctx context.Context, c jsmClient, spec apis.StreamSpec) (err e
 			HeadersOnly: spec.Republish.HeadersOnly,
 		}
 	}
+	if spec.Mirror != nil {
+		ss, err := getStreamSource(spec.Mirror)
+		if err != nil {
+			return err
+		}
+
+		config.Mirror = ss
+	}
 
 	return js.UpdateConfiguration(config)
 }

--- a/controllers/jetstream/stream.go
+++ b/controllers/jetstream/stream.go
@@ -402,6 +402,14 @@ func updateStream(ctx context.Context, c jsmClient, spec apis.StreamSpec) (err e
 
 		config.Mirror = ss
 	}
+	config.Sources = make([]*jsmapi.StreamSource, len(spec.Sources))
+	for i, ss := range spec.Sources {
+		jss, err := getStreamSource(ss)
+		if err != nil {
+			return err
+		}
+		config.Sources[i] = jss
+	}
 
 	return js.UpdateConfiguration(config)
 }


### PR DESCRIPTION
Currently, there is no option to update Mirror or Source fields on streams, as already mentioned on https://github.com/nats-io/nack/issues/58

This PR adds support for both:
- Mirror: based on the docs, can be updated if not defined. I wasn't able to find a way to get that info but in any case, is better than nothing. If we try to change the mirror once, set an error will be raised anyway.
- Sources: based on the docs, can be updated.