### PR TITLE
Expose AllowDirect field for streams CRD

### DIFF
--- a/controllers/jetstream/stream.go
+++ b/controllers/jetstream/stream.go
@@ -369,6 +369,10 @@ func createStream(ctx context.Context, c jsmClient, spec apis.StreamSpec) (err e
 		}))
 	}
 
+	if spec.AllowDirect {
+		opts = append(opts, jsm.AllowDirect())
+	}
+
 	_, err = c.NewStream(ctx, spec.Name, opts)
 	return err
 }
@@ -413,6 +417,7 @@ func updateStream(ctx context.Context, c jsmClient, spec apis.StreamSpec) (err e
 		Replicas:     spec.Replicas,
 		NoAck:        spec.NoAck,
 		Duplicates:   duplicates,
+		AllowDirect:  spec.AllowDirect,
 	}
 	if spec.Republish != nil {
 		config.RePublish = &jsmapi.RePublish{

--- a/deploy/crds.yml
+++ b/deploy/crds.yml
@@ -193,6 +193,10 @@ spec:
                 description: When true, the managed Stream will not be deleted when the resource is deleted
                 type: boolean
                 default: false
+              allowDirect:
+                description: When true, allow higher performance, direct access to get individual messages
+                type: boolean
+                default: false
           status:
             type: object
             properties:

--- a/pkg/jetstream/apis/jetstream/v1beta2/streamtypes.go
+++ b/pkg/jetstream/apis/jetstream/v1beta2/streamtypes.go
@@ -23,6 +23,7 @@ func (s *Stream) GetSpec() interface{} {
 // StreamSpec is the spec for a Stream resource
 type StreamSpec struct {
 	Account           string           `json:"account"`
+	AllowDirect       bool             `json:"allowDirect"`
 	Creds             string           `json:"creds"`
 	Description       string           `json:"description"`
 	PreventDelete     bool             `json:"preventDelete"`


### PR DESCRIPTION
Our team is using the jsc to create streams, when creating streams we notice there was no way to configure the AllowDirect field. This PR exposes exposes the AllowDirect field when creating and updating streams.

Tested by building the image locally and pushing to our teams registry and running the jsc pod with this image, validated the AllowDirect field can be updated on an existing stream and set on stream creation.