### PR TITLE
Expose AllowRollup & DenyDelete field for streams CRD

### DIFF
--- a/controllers/jetstream/stream.go
+++ b/controllers/jetstream/stream.go
@@ -373,6 +373,14 @@ func createStream(ctx context.Context, c jsmClient, spec apis.StreamSpec) (err e
 		opts = append(opts, jsm.AllowDirect())
 	}
 
+	if spec.AllowRollup {
+		opts = append(opts, jsm.AllowRollup())
+	}
+
+	if spec.DenyDelete {
+		opts = append(opts, jsm.DenyDelete())
+	}
+
 	_, err = c.NewStream(ctx, spec.Name, opts)
 	return err
 }
@@ -404,20 +412,22 @@ func updateStream(ctx context.Context, c jsmClient, spec apis.StreamSpec) (err e
 	}
 
 	config := jsmapi.StreamConfig{
-		Name:         spec.Name,
-		Retention:    retention,
-		Subjects:     spec.Subjects,
-		MaxConsumers: spec.MaxConsumers,
-		MaxMsgs:      int64(spec.MaxMsgs),
-		MaxBytes:     int64(spec.MaxBytes),
-		MaxAge:       maxAge,
-		MaxMsgSize:   int32(spec.MaxMsgSize),
-		Storage:      storage,
-		Discard:      discard,
-		Replicas:     spec.Replicas,
-		NoAck:        spec.NoAck,
-		Duplicates:   duplicates,
-		AllowDirect:  spec.AllowDirect,
+		Name:          spec.Name,
+		Retention:     retention,
+		Subjects:      spec.Subjects,
+		MaxConsumers:  spec.MaxConsumers,
+		MaxMsgs:       int64(spec.MaxMsgs),
+		MaxBytes:      int64(spec.MaxBytes),
+		MaxAge:        maxAge,
+		MaxMsgSize:    int32(spec.MaxMsgSize),
+		Storage:       storage,
+		Discard:       discard,
+		Replicas:      spec.Replicas,
+		NoAck:         spec.NoAck,
+		Duplicates:    duplicates,
+		AllowDirect:   spec.AllowDirect,
+		DenyDelete:    spec.DenyDelete,
+		RollupAllowed: spec.AllowRollup,
 	}
 	if spec.Republish != nil {
 		config.RePublish = &jsmapi.RePublish{

--- a/deploy/crds.yml
+++ b/deploy/crds.yml
@@ -197,6 +197,14 @@ spec:
                 description: When true, allow higher performance, direct access to get individual messages
                 type: boolean
                 default: false
+              allowRollup:
+                description: When true, allows the use of the Nats-Rollup header to replace all contents of a stream, or subject in a stream, with a single new message.
+                type: boolean
+                default: false
+              denyDelete:
+                description: When true, restricts the ability to delete messages from a stream via the API. Cannot be changed once set to true.
+                type: boolean
+                default: false
           status:
             type: object
             properties:

--- a/pkg/jetstream/apis/jetstream/v1beta2/streamtypes.go
+++ b/pkg/jetstream/apis/jetstream/v1beta2/streamtypes.go
@@ -24,7 +24,9 @@ func (s *Stream) GetSpec() interface{} {
 type StreamSpec struct {
 	Account           string           `json:"account"`
 	AllowDirect       bool             `json:"allowDirect"`
+	AllowRollup       bool             `json:"allowRollup"`
 	Creds             string           `json:"creds"`
+	DenyDelete        bool             `json:"denyDelete"`
 	Description       string           `json:"description"`
 	PreventDelete     bool             `json:"preventDelete"`
 	Discard           string           `json:"discard"`


### PR DESCRIPTION
Our team is using the jsc to create streams, when creating streams we notice there was no way to configure the AllowRollup & DenyDelete fields. This PR exposes exposes the AllowRollup & DenyDelete fields when creating and updating streams.

Tested by building the image locally and pushing to our teams registry and running the jsc pod with this image, validated the AllowRollup & DenyDelete fields can be updated on an existing stream and set on stream creation.