### PR TITLE
Rework cleanup

### DIFF
--- a/cmd/jetstream-controller/main.go
+++ b/cmd/jetstream-controller/main.go
@@ -60,6 +60,7 @@ func run() error {
 	server := flag.String("s", "", "NATS Server URL")
 	crdConnect := flag.Bool("crd-connect", false, "If true, then NATS connections will be made from CRD config, not global config")
 	cleanupPeriod := flag.Duration("cleanup-period", 30*time.Second, "Period to run object cleanup")
+	readOnly := flag.Bool("read-only", false, "Starts the controller without causing changes to the NATS resources")
 	flag.Parse()
 
 	if *version {
@@ -115,9 +116,13 @@ func run() error {
 		Namespace:       *namespace,
 		CRDConnect:      *crdConnect,
 		CleanupPeriod:   *cleanupPeriod,
+		ReadOnly:        *readOnly,
 	})
 
 	klog.Infof("Starting %s v%s...", os.Args[0], Version)
+	if *readOnly {
+		klog.Infof("Running in read-only mode: JetStream state in server will not be changed")
+	}
 	go handleSignals(cancel)
 	return ctrl.Run()
 }

--- a/controllers/jetstream/consumer.go
+++ b/controllers/jetstream/consumer.go
@@ -20,6 +20,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	k8smeta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
+	klog "k8s.io/klog/v2"
 )
 
 func (c *Controller) runConsumerQueue() {
@@ -408,7 +409,7 @@ func deleteConsumer(ctx context.Context, c jsmClient, spec apis.ConsumerSpec) (e
 	}()
 
 	if spec.PreventDelete {
-		fmt.Printf("Consumer %q is configured to preventDelete on stream %q:\n", stream, consumer)
+		klog.Infof("Consumer %q is configured to preventDelete on stream %q:", stream, consumer)
 		return nil
 	}
 

--- a/controllers/jetstream/consumer.go
+++ b/controllers/jetstream/consumer.go
@@ -58,8 +58,10 @@ func (c *Controller) processConsumerObject(cns *apis.Consumer, jsmc jsmClient) (
 		accServers       []string
 	)
 	if spec.Account != "" && c.opts.CRDConnect {
-		// Lookup the account.
-		acc, err := c.accLister.Accounts(ns).Get(spec.Account)
+		// Lookup the account using the REST client.
+		ctx, done := context.WithTimeout(context.Background(), 5*time.Second)
+		defer done()
+		acc, err := c.ji.Accounts(ns).Get(ctx, spec.Account, k8smeta.GetOptions{})
 		if err != nil {
 			return err
 		}
@@ -90,6 +92,7 @@ func (c *Controller) processConsumerObject(cns *apis.Consumer, jsmc jsmClient) (
 				}
 			}
 		}
+		// FIXME: Add support for UserCredentials for consumer.
 	}
 
 	defer func() {

--- a/controllers/jetstream/controller.go
+++ b/controllers/jetstream/controller.go
@@ -77,6 +77,7 @@ type Options struct {
 	Namespace     string
 	CRDConnect    bool
 	CleanupPeriod time.Duration
+	ReadOnly      bool
 
 	Recorder record.EventRecorder
 }
@@ -258,6 +259,9 @@ func streamsMap(ss []*apis.Stream) map[string]*apis.Stream {
 }
 
 func (c *Controller) cleanupStreams() error {
+	if c.opts.ReadOnly {
+		return nil
+	}
 	tick := time.NewTicker(c.opts.CleanupPeriod)
 	defer tick.Stop()
 
@@ -325,6 +329,9 @@ func consumerMap(cs []*apis.Consumer) map[string]*apis.Consumer {
 }
 
 func (c *Controller) cleanupConsumers() error {
+	if c.opts.ReadOnly {
+		return nil
+	}
 	tick := time.NewTicker(c.opts.CleanupPeriod)
 	defer tick.Stop()
 

--- a/controllers/jetstream/controller.go
+++ b/controllers/jetstream/controller.go
@@ -33,6 +33,7 @@ import (
 
 	k8sapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	k8smeta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -238,7 +239,7 @@ func (c *Controller) Run() error {
 	return nil
 }
 
-func deletedStreams(prev, cur map[string]*apis.Stream) []*apis.Stream {
+func selectMissingStreamsFromList(prev, cur map[string]*apis.Stream) []*apis.Stream {
 	var deleted []*apis.Stream
 	for name, ps := range prev {
 		if _, ok := cur[name]; !ok {
@@ -248,7 +249,7 @@ func deletedStreams(prev, cur map[string]*apis.Stream) []*apis.Stream {
 	return deleted
 }
 
-func streamMap(ss []*apis.Stream) map[string]*apis.Stream {
+func streamsMap(ss []*apis.Stream) map[string]*apis.Stream {
 	m := make(map[string]*apis.Stream)
 	for _, s := range ss {
 		m[fmt.Sprintf("%s/%s", s.Namespace, s.Name)] = s
@@ -260,6 +261,7 @@ func (c *Controller) cleanupStreams() error {
 	tick := time.NewTicker(c.opts.CleanupPeriod)
 	defer tick.Stop()
 
+	// Track the Stream CRDs that may have been created.
 	var prevStreams map[string]*apis.Stream
 	for {
 		select {
@@ -271,23 +273,40 @@ func (c *Controller) cleanupStreams() error {
 				klog.Infof("failed to list streams for cleanup: %s", err)
 				continue
 			}
-			sm := streamMap(streams)
-
-			for _, s := range deletedStreams(prevStreams, sm) {
-				t := k8smeta.NewTime(time.Now())
-				s.DeletionTimestamp = &t
-				if err := c.processStreamObject(s, &realJsmClient{jm: c.jm}); err != nil {
-					klog.Infof("failed to delete stream %s/%s: %s", s.Namespace, s.Name, err)
-					continue
+			sm := streamsMap(streams)
+			missing := selectMissingStreamsFromList(prevStreams, sm)
+			for _, s := range missing {
+				// A stream that we were tracking but that for some reason
+				// was not part of the latest list shared by informer.
+				// Need to double check whether the stream is present before
+				// considering deletion.
+				klog.Infof("stream %s/%s might be missing, looking it up...", s.Namespace, s.Name)
+				ctx, done := context.WithTimeout(context.Background(), 10*time.Second)
+				defer done()
+				_, err := c.ji.Streams(s.Namespace).Get(ctx, s.Name, k8smeta.GetOptions{})
+				if err != nil {
+					if k8serrors.IsNotFound(err) {
+						klog.Infof("stream %s/%s was not found anymore, deleting from JetStream", s.Namespace, s.Name)
+						t := k8smeta.NewTime(time.Now())
+						s.DeletionTimestamp = &t
+						if err := c.processStreamObject(s, &realJsmClient{jm: c.jm}); err != nil && !k8serrors.IsNotFound(err) {
+							klog.Infof("failed to delete stream %s/%s: %s", s.Namespace, s.Name, err)
+							continue
+						}
+						klog.Infof("deleted stream %s/%s from JetStream", s.Namespace, s.Name)
+					} else {
+						klog.Warningf("error looking up stream %s/%s", s.Namespace, s.Name)
+					}
+				} else {
+					klog.Infof("found stream %s/%s, no further action needed", s.Namespace, s.Name)
 				}
-				klog.Infof("deleted stream %s/%s", s.Namespace, s.Name)
 			}
 			prevStreams = sm
 		}
 	}
 }
 
-func deletedConsumers(prev, cur map[string]*apis.Consumer) []*apis.Consumer {
+func selectMissingConsumersFromList(prev, cur map[string]*apis.Consumer) []*apis.Consumer {
 	var deleted []*apis.Consumer
 	for name, ps := range prev {
 		if _, ok := cur[name]; !ok {
@@ -309,6 +328,7 @@ func (c *Controller) cleanupConsumers() error {
 	tick := time.NewTicker(c.opts.CleanupPeriod)
 	defer tick.Stop()
 
+	// Track consumers that may have been deleted.
 	var prevConsumers map[string]*apis.Consumer
 	for {
 		select {
@@ -321,15 +341,32 @@ func (c *Controller) cleanupConsumers() error {
 				continue
 			}
 			cm := consumerMap(consumers)
-
-			for _, cns := range deletedConsumers(prevConsumers, cm) {
-				t := k8smeta.NewTime(time.Now())
-				cns.DeletionTimestamp = &t
-				if err := c.processConsumerObject(cns, &realJsmClient{jm: c.jm}); err != nil {
-					klog.Infof("failed to delete consumer %s/%s: %s", cns.Namespace, cns.Name, err)
-					continue
+			missing := selectMissingConsumersFromList(prevConsumers, cm)
+			for _, cns := range missing {
+				// A consumer that we were tracking but that for some reason
+				// was not part of the latest list shared by informer.
+				// Need to double check whether the consumer is present before
+				// considering deletion.
+				klog.Infof("consumer %s/%s might be missing, looking it up...", cns.Namespace, cns.Name)
+				ctx, done := context.WithTimeout(context.Background(), 10*time.Second)
+				defer done()
+				_, err := c.ji.Consumers(cns.Namespace).Get(ctx, cns.Name, k8smeta.GetOptions{})
+				if err != nil {
+					if k8serrors.IsNotFound(err) {
+						klog.Infof("consumer %s/%s was not found anymore, deleting from JetStream", cns.Namespace, cns.Name)
+						t := k8smeta.NewTime(time.Now())
+						cns.DeletionTimestamp = &t
+						if err := c.processConsumerObject(cns, &realJsmClient{jm: c.jm}); err != nil && !k8serrors.IsNotFound(err) {
+							klog.Infof("failed to delete consumer %s/%s: %s", cns.Namespace, cns.Name, err)
+							continue
+						}
+						klog.Infof("deleted consumer %s/%s from JetStream", cns.Namespace, cns.Name)
+					} else {
+						klog.Warningf("error looking up consumer %s/%s", cns.Namespace, cns.Name)
+					}
+				} else {
+					klog.Infof("found consumer %s/%s, no further action needed", cns.Namespace, cns.Name)
 				}
-				klog.Infof("deleted consumer %s/%s", cns.Namespace, cns.Name)
 			}
 			prevConsumers = cm
 		}

--- a/controllers/jetstream/stream.go
+++ b/controllers/jetstream/stream.go
@@ -73,9 +73,10 @@ func (c *Controller) processStreamObject(str *apis.Stream, jsmc jsmClient) (err 
 		accUserCreds     string
 	)
 	if spec.Account != "" && c.opts.CRDConnect {
-		// Lookup the account.
-		var err error
-		acc, err = c.accLister.Accounts(ns).Get(spec.Account)
+		// Lookup the account using the REST client.
+		ctx, done := context.WithTimeout(context.Background(), 5*time.Second)
+		defer done()
+		acc, err = c.ji.Accounts(ns).Get(ctx, spec.Account, k8smeta.GetOptions{})
 		if err != nil {
 			return err
 		}

--- a/controllers/jetstream/stream.go
+++ b/controllers/jetstream/stream.go
@@ -440,6 +440,7 @@ func updateStream(ctx context.Context, c jsmClient, spec apis.StreamSpec) (err e
 
 	config := jsmapi.StreamConfig{
 		Name:          spec.Name,
+		Description:   spec.Description,
 		Retention:     retention,
 		Subjects:      spec.Subjects,
 		MaxConsumers:  spec.MaxConsumers,


### PR DESCRIPTION
- Fix potential issue where an informer may not have the complete entries about consumers/streams and cause unintended deletes
- Add -read-only mode flag to let the controller run 
- Add missing description to Stream on update
- Change account lookups to use the REST client instead of informers