### PR TITLE
Fix 3 space indentation in crds.yaml

### DIFF
--- a/deploy/crds.yml
+++ b/deploy/crds.yml
@@ -194,9 +194,9 @@ spec:
                 type: boolean
                 default: false
               preventUpdate:
-                 description: When true, the managed Stream will not be updated when the resource is updated
-                 type: boolean
-                 default: false
+                description: When true, the managed Stream will not be updated when the resource is updated
+                type: boolean
+                default: false
               allowDirect:
                 description: When true, allow higher performance, direct access to get individual messages
                 type: boolean


### PR DESCRIPTION
Prior to this change, there was a 3-space indentation for elements in the crds.yaml. This change removes the extra space to align with a 2-space indentation.