### PR TITLE
Change default value for `ackWait` from `1ns` to `30s`

### DIFF
--- a/deploy/crds.yml
+++ b/deploy/crds.yml
@@ -474,7 +474,7 @@ spec:
               ackWait:
                 description: How long to allow messages to remain un-acknowledged before attempting redelivery.
                 type: string
-                default: 1ns
+                default: 30s
               maxDeliver:
                 type: integer
                 minimum: -1
@@ -667,7 +667,7 @@ spec:
               ackWait:
                 description: How long to allow messages to remain un-acknowledged before attempting redelivery.
                 type: string
-                default: 1ns
+                default: 30s
               maxDeliver:
                 type: integer
                 minimum: -1


### PR DESCRIPTION
Hi there!

I ran into a problem with my application which is run on the k8s cluster with 2 pods.
The application uses a stream (WorkQueue) and a pull consumer with `ackWait` settings by default.
The problem was that the messages received both pods as the same time.

I think that the default value for `ackWait` should be more than 1 nanosecond.