### PR TITLE
Bump GH Action versions (Go; node12 deprecations)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,19 +8,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Setup Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version: '1.19'
 
     - name: Setup QEMU
       uses: docker/setup-qemu-action@v2
 
     - name: Setup Docker Buildx
       id: buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
 
     - name: Setup Docker Hub
       uses: docker/login-action@v2
@@ -35,6 +35,12 @@ jobs:
         echo tags="latest,${version}" >> $GITHUB_OUTPUT
 
     - name: Build and Push
+      # 2023-05-07 note: the action documents:
+      #   This repository is considered EXPERIMENTAL and under active development
+      #   until further notice. It is subject to non-backward compatible changes
+      #   or removal in any future version
+      # thus while v3.0.1 is the latest, I'm leaving this on v2 for an owner to
+      # investigate.
       uses: docker/bake-action@v2
       env:
         TAGS: "${{ steps.tags.outputs.tags }}"

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -11,11 +11,11 @@ jobs:
     steps:
     - name: Setup Go
       id: setup-go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
-        go-version: ^1.17
+        go-version: '^1.19'
     - name: Checkout source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Build
       run: make build
     - name: Test


### PR DESCRIPTION
Bump various GitHub Actions versions to be more current, to avoid the node.js 12 deprecation notices.

Bump Go to 1.19 where applicable, and quote the version strings.

Note that actions/setup-go@v4 is now available, with more caching, but I deliberately chose to not explore that at this time and instead to stick to the v3 upgrade, which we've done in many other repos and know is safe.

Add a warning comment by the use of the bake-action.
