### PR TITLE
Fix nats-server-config-reloader for k8s secrets

### DIFF
--- a/pkg/natsreloader/natsreloader.go
+++ b/pkg/natsreloader/natsreloader.go
@@ -11,11 +11,14 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
 )
+
+const errorFmt = "Error: %s\n"
 
 // Config represents the configuration of the reloader.
 type Config struct {
@@ -45,7 +48,7 @@ type Reloader struct {
 func (r *Reloader) waitForProcess() error {
 	var proc *os.Process
 	var pid int
-	var attempts int = 0
+	attempts := 0
 
 	startTime := time.Now()
 	for {
@@ -66,17 +69,17 @@ func (r *Reloader) waitForProcess() error {
 		break
 
 	WaitAndRetry:
-		log.Printf("Error: %s\n", err)
+		log.Printf(errorFmt, err)
 		attempts++
 		if attempts > r.MaxRetries {
-			return fmt.Errorf("Too many errors attempting to find server process")
+			return fmt.Errorf("too many errors attempting to find server process")
 		}
 		time.Sleep(time.Duration(r.RetryWaitSecs) * time.Second)
 	}
 
 	if attempts > 0 {
 		log.Printf("found pid from pidfile %q after %v failed attempts (%v time after start)",
-			r.PidFile, attempts, time.Now().Sub(startTime))
+			r.PidFile, attempts, time.Since(startTime))
 	}
 
 	r.pid = pid
@@ -84,23 +87,113 @@ func (r *Reloader) waitForProcess() error {
 	return nil
 }
 
-// Run starts the main loop.
-func (r *Reloader) Run(ctx context.Context) error {
-	ctx, cancel := context.WithCancel(ctx)
-	r.quit = func() {
-		cancel()
+func removeDuplicateStrings(s []string) []string {
+	if len(s) < 1 {
+		return s
 	}
 
+	sort.Strings(s)
+	prev := 1
+	for curr := 1; curr < len(s); curr++ {
+		if s[curr-1] != s[curr] {
+			s[prev] = s[curr]
+			prev++
+		}
+	}
+
+	return s[:prev]
+}
+
+func getFileDigest(filePath string) ([]byte, error) {
+	h := sha256.New()
+	f, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+	if _, err := io.Copy(h, f); err != nil {
+		return nil, err
+	}
+	return h.Sum(nil), nil
+}
+
+func handleEvent(event fsnotify.Event, lastConfigAppliedCache map[string][]byte, updatedFiles, deletedFiles []string) ([]string, []string) {
+	if event.Op&fsnotify.Remove == fsnotify.Remove {
+		// We don't get a Remove event for the directory itself, so
+		// we need to detect that separately.
+		return updatedFiles, append(deletedFiles, event.Name)
+	}
+	_, err := os.Stat(event.Name)
+	if err != nil {
+		// Beware that this means that we won't reconfigure if a file
+		// is permanently removed.  We want to support transient
+		// disappearance, waiting for the new content, and have not set
+		// up any sort of longer-term timers to detect permanent
+		// deletion.
+		// If you really need this, then switch a file to be empty
+		// before removing if afterwards.
+		return updatedFiles, deletedFiles
+	}
+
+	if len(updatedFiles) > 0 {
+		return updatedFiles, deletedFiles
+	}
+	digest, err := getFileDigest(event.Name)
+	if err != nil {
+		log.Printf(errorFmt, err)
+		return updatedFiles, deletedFiles
+	}
+
+	lastConfigHash, ok := lastConfigAppliedCache[event.Name]
+	if ok && bytes.Equal(lastConfigHash, digest) {
+		return updatedFiles, deletedFiles
+	}
+
+	log.Printf("Changed config; file=%q existing=%v total-files=%d",
+		event.Name, ok, len(lastConfigAppliedCache))
+	lastConfigAppliedCache[event.Name] = digest
+	return append(updatedFiles, event.Name), deletedFiles
+}
+
+// handleEvents handles all events in the queue. It returns the updated and deleted files and can contain duplicates.
+func handleEvents(configWatcher *fsnotify.Watcher, event fsnotify.Event, lastConfigAppliedCache map[string][]byte) ([]string, []string) {
+	updatedFiles, deletedFiles := handleEvent(event, lastConfigAppliedCache, make([]string, 0, 16), make([]string, 0, 16))
+	for {
+		select {
+		case event := <-configWatcher.Events:
+			updatedFiles, deletedFiles = handleEvent(event, lastConfigAppliedCache, updatedFiles, deletedFiles)
+		default:
+			return updatedFiles, deletedFiles
+		}
+	}
+}
+
+func handleDeletedFiles(deletedFiles []string, configWatcher *fsnotify.Watcher, lastConfigAppliedCache map[string][]byte) ([]string, []string) {
+	log.Printf("Ticker is running with deletedFiles %v", deletedFiles)
+	newDeletedFiles := make([]string, 0, len(deletedFiles))
+	updated := make([]string, 0, len(deletedFiles))
+	for _, f := range deletedFiles {
+		if err := configWatcher.Add(f); err != nil {
+			newDeletedFiles = append(newDeletedFiles, f)
+		} else {
+			updated, _ = handleEvent(fsnotify.Event{Name: f, Op: fsnotify.Create}, lastConfigAppliedCache, updated, nil)
+		}
+	}
+	return removeDuplicateStrings(updated), newDeletedFiles
+}
+
+func (r *Reloader) init() (*fsnotify.Watcher, map[string][]byte, error) {
 	err := r.waitForProcess()
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 
 	configWatcher, err := fsnotify.NewWatcher()
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
-	defer configWatcher.Close()
 
 	// Follow configuration updates in the directory where
 	// the config file is located and trigger reload when
@@ -108,14 +201,19 @@ func (r *Reloader) Run(ctx context.Context) error {
 	for i := range r.ConfigFiles {
 		// Ensure our paths are canonical
 		r.ConfigFiles[i], _ = filepath.Abs(r.ConfigFiles[i])
-		// Use directory here because k8s remounts the entire folder
-		// the config file lives in. So, watch the folder so we properly receive events.
-		if err := configWatcher.Add(filepath.Dir(r.ConfigFiles[i])); err != nil {
-			return err
+	}
+	r.ConfigFiles = removeDuplicateStrings(r.ConfigFiles)
+	// Follow configuration file updates and trigger reload when
+	// it is either recreated or written into.
+	for i := range r.ConfigFiles {
+		// Watch files individually for https://github.com/kubernetes/kubernetes/issues/112677
+		if err := configWatcher.Add(r.ConfigFiles[i]); err != nil {
+			_ = configWatcher.Close()
+			return nil, nil, err
 		}
+		log.Printf("Watching file: %v", r.ConfigFiles[i])
 	}
 
-	attempts := 0
 	// lastConfigAppliedCache is the last config update
 	// applied by us
 	lastConfigAppliedCache := make(map[string][]byte)
@@ -123,17 +221,12 @@ func (r *Reloader) Run(ctx context.Context) error {
 	// Preload config hashes, so we know their digests
 	// up front and avoid potentially reloading when unnecessary.
 	for _, configFile := range r.ConfigFiles {
-		h := sha256.New()
-		f, err := os.Open(configFile)
+		digest, err := getFileDigest(configFile)
 		if err != nil {
-			return err
+			_ = configWatcher.Close()
+			return nil, nil, err
 		}
-		if _, err := io.Copy(h, f); err != nil {
-			return err
-		}
-		digest := h.Sum(nil)
 		lastConfigAppliedCache[configFile] = digest
-		f.Close()
 	}
 
 	// If the two pids don't match then os.FindProcess() has done something
@@ -147,85 +240,95 @@ func (r *Reloader) Run(ctx context.Context) error {
 		log.Printf("Error: no watched config files cached; input spec was: %#v",
 			r.ConfigFiles)
 	}
+	return configWatcher, lastConfigAppliedCache, nil
+}
 
-	var triggerName string
-	var updatedFiles bool
+func (r *Reloader) reload(updatedFiles []string) error {
+	attempts := 0
+	for {
+		log.Printf("Sending signal '%s' to server to reload configuration due to: %s", r.Signal.String(), updatedFiles)
+		err := r.proc.Signal(r.Signal)
+		if err == nil {
+			return nil
+		}
+		log.Printf("Error during reload: %s\n", err)
+		if attempts > r.MaxRetries {
+			return fmt.Errorf("too many errors (%v) attempting to signal server to reload: %w", attempts, err)
+		}
+		delay := retryJitter(time.Duration(r.RetryWaitSecs) * time.Second)
+		log.Printf("Wait and retrying after some time [%v] ...", delay)
+		time.Sleep(delay)
+		attempts++
+	}
+}
+
+// Run starts the main loop.
+func (r *Reloader) Run(ctx context.Context) error {
+	ctx, cancel := context.WithCancel(ctx)
+	r.quit = func() {
+		cancel()
+	}
+
+	configWatcher, lastConfigAppliedCache, err := r.init()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = configWatcher.Close()
+	}()
+
+	// We use a ticker to re-add deleted files to the watcher
+	t := time.NewTicker(time.Second)
+	t.Stop()
+	defer t.Stop()
+	var tickerRunning bool
+	var deletedFiles []string
+	var updatedFiles []string
 
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
-		case event := <-configWatcher.Events:
-			triggerName = event.Name
-
-			_, err := os.Stat(event.Name)
-			if err != nil {
-				// Beware that this means that we won't reconfigure if a file
-				// is permanently removed.  We want to support transient
-				// disappearance, waiting for the new content, and have not set
-				// up any sort of longer-term timers to detect permanent
-				// deletion.
-				// If you really need this, then switch a file to be empty
-				// before removing if afterwards.
-				continue
+		case <-t.C:
+			updatedFiles, deletedFiles = handleDeletedFiles(deletedFiles, configWatcher, lastConfigAppliedCache)
+			if len(deletedFiles) == 0 {
+				// No more deleted files, stop the ticker
+				t.Stop()
+				tickerRunning = false
 			}
-
-			updatedFiles = false
-			for _, configFile := range r.ConfigFiles {
-				h := sha256.New()
-				f, err := os.Open(configFile)
-				if err != nil {
-					log.Printf("Error: %s\n", err)
-					continue
-				}
-				if _, err := io.Copy(h, f); err != nil {
-					log.Printf("Error: %s\n", err)
-					continue
-				}
-				digest := h.Sum(nil)
-				lastConfigHash, ok := lastConfigAppliedCache[configFile]
-				if ok && bytes.Equal(lastConfigHash, digest) {
-					// No meaningful change or this is the first time we've checked
-					continue
-				}
-				lastConfigAppliedCache[configFile] = digest
-
-				log.Printf("changed config; file=%q existing=%v total-files=%d",
-					configFile, ok, len(lastConfigAppliedCache))
-
-				updatedFiles = true
-
-				// We only get an event for one file at a time, we can stop checking
-				// config files here and continue with our business.
+			if len(updatedFiles) > 0 {
+				// Send signal to reload the config
+				log.Printf("Updated files: %v", updatedFiles)
 				break
 			}
-			if !updatedFiles {
-				continue
+			continue
+			// Check if the process is still alive
+		case event := <-configWatcher.Events:
+			updated, deleted := handleEvents(configWatcher, event, lastConfigAppliedCache)
+			updatedFiles = removeDuplicateStrings(updated)
+			deletedFiles = removeDuplicateStrings(append(deletedFiles, deleted...))
+			if !tickerRunning {
+				// Start the ticker to re-add deleted files
+				t.Reset(time.Second)
+				tickerRunning = true
 			}
+			if len(updatedFiles) > 0 {
+				// Send signal to reload the config
+				log.Printf("Updated files: %v", updatedFiles)
+				break
+			}
+			continue
 		case err := <-configWatcher.Errors:
-			log.Printf("Error: %s\n", err)
+			log.Printf(errorFmt, err)
 			continue
 		}
-
 		// Configuration was updated, try to do reload for a few times
 		// otherwise give up and wait for next event.
-	TryReload:
-		for {
-			log.Printf("Sending signal '%s' to server to reload configuration due to: %s", r.Signal.String(), triggerName)
-			err := r.proc.Signal(r.Signal)
-			if err != nil {
-				log.Printf("Error during reload: %s\n", err)
-				if attempts > r.MaxRetries {
-					return fmt.Errorf("Too many errors (%v) attempting to signal server to reload", attempts)
-				}
-				delay := retryJitter(time.Duration(r.RetryWaitSecs) * time.Second)
-				log.Printf("Wait and retrying after some time [%v] ...", delay)
-				time.Sleep(delay)
-				attempts++
-				continue TryReload
-			}
-			break TryReload
+		err := r.reload(updatedFiles)
+		if err != nil {
+			return err
 		}
+		updatedFiles = nil
 	}
 }
 

--- a/pkg/natsreloader/natsreloader.go
+++ b/pkg/natsreloader/natsreloader.go
@@ -110,9 +110,7 @@ func getFileDigest(filePath string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		_ = f.Close()
-	}()
+	defer f.Close()
 	if _, err := io.Copy(h, f); err != nil {
 		return nil, err
 	}
@@ -120,7 +118,7 @@ func getFileDigest(filePath string) ([]byte, error) {
 }
 
 func handleEvent(event fsnotify.Event, lastConfigAppliedCache map[string][]byte, updatedFiles, deletedFiles []string) ([]string, []string) {
-	if event.Op&fsnotify.Remove == fsnotify.Remove {
+	if event.Has(fsnotify.Remove) {
 		// We don't get a Remove event for the directory itself, so
 		// we need to detect that separately.
 		return updatedFiles, append(deletedFiles, event.Name)
@@ -273,9 +271,7 @@ func (r *Reloader) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	defer func() {
-		_ = configWatcher.Close()
-	}()
+	defer configWatcher.Close()
 
 	// We use a ticker to re-add deleted files to the watcher
 	t := time.NewTicker(time.Second)

--- a/pkg/natsreloader/natsreloadertest/natsreloader_test.go
+++ b/pkg/natsreloader/natsreloadertest/natsreloader_test.go
@@ -2,6 +2,7 @@ package natsreloadertest
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -56,11 +57,10 @@ func TestReloader(t *testing.T) {
 
 	r, err := natsreloader.NewReloader(nconfig)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
-		os.Exit(1)
+		t.Fatal(err)
 	}
 
-	var signals = 0
+	signals := 0
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -109,7 +109,7 @@ func TestReloader(t *testing.T) {
 	}()
 
 	err = r.Run(ctx)
-	if err != nil && err != context.Canceled {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		t.Fatal(err)
 	}
 	// We should have gotten only one signal for each configuration file


### PR DESCRIPTION
Fixes #130

To fix this issue, the commit ensures that when a file is deleted, the Inotify watches immediately unregister it and then attempt to periodically re-register the file every second until the operation succeeds. This guarantees that the file will continue to be monitored reliably even after deletion.