### PR TITLE
Fixes to config reloader for when server pid changes

### DIFF
--- a/cmd/jetstream-controller/main.go
+++ b/cmd/jetstream-controller/main.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2022 The NATS Authors
+// Copyright 2020-2023 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/cmd/nats-server-config-reloader/main.go
+++ b/cmd/nats-server-config-reloader/main.go
@@ -58,8 +58,8 @@ func main() {
 	fs.StringVar(&nconfig.PidFile, "pid", "/var/run/nats/gnatsd.pid", "NATS Server Pid File")
 	fs.Var(&fileSet, "c", "NATS Server Config File (may be repeated to specify more than one)")
 	fs.Var(&fileSet, "config", "NATS Server Config File (may be repeated to specify more than one)")
-	fs.IntVar(&nconfig.MaxRetries, "max-retries", 5, "Max attempts to trigger reload")
-	fs.IntVar(&nconfig.RetryWaitSecs, "retry-wait-secs", 2, "Time to back off when reloading fails before retrying")
+	fs.IntVar(&nconfig.MaxRetries, "max-retries", 30, "Max attempts to trigger reload")
+	fs.IntVar(&nconfig.RetryWaitSecs, "retry-wait-secs", 4, "Time to back off when reloading fails before retrying")
 	fs.IntVar(&customSignal, "signal", 1, "Signal to send to the NATS Server process (default SIGHUP 1)")
 
 	fs.Parse(os.Args[1:])

--- a/pkg/natsreloader/natsreloadertest/natsreloader_test.go
+++ b/pkg/natsreloader/natsreloadertest/natsreloader_test.go
@@ -1,3 +1,16 @@
+// Copyright 2020-2023 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package natsreloadertest
 
 import (


### PR DESCRIPTION
- Fixed to always check if process is still alive before sending signal.

- Changed defaults to reloader to attempt reloading for 2 minutes in case of errors.