### PR TITLE
Update alpine version - CVE-2022-48174

### DIFF
--- a/cicd/Dockerfile
+++ b/cicd/Dockerfile
@@ -1,7 +1,7 @@
 #syntax=docker/dockerfile-upstream:1.5
 ARG GO_APP
 
-FROM alpine:3.18.2 as deps
+FROM alpine:3.18.5 as deps
 
 ARG GO_APP
 ARG GORELEASER_DIST_DIR=/go/src/dist

--- a/cicd/Dockerfile
+++ b/cicd/Dockerfile
@@ -1,7 +1,7 @@
 #syntax=docker/dockerfile-upstream:1.5
 ARG GO_APP
 
-FROM alpine:3.18.5 as deps
+FROM alpine:3.19 as deps
 
 ARG GO_APP
 ARG GORELEASER_DIST_DIR=/go/src/dist
@@ -28,7 +28,7 @@ RUN <<EOT
   cp ${BIN_PATH} /go/bin
 EOT
 
-FROM alpine:3.18.2
+FROM alpine:3.19
 
 ARG GO_APP
 ENV GO_APP ${GO_APP}


### PR DESCRIPTION
Update alpine patch version to fix a busybox critical CVE. (prevent current image to run on secured K8s clusters).