### PR TITLE
feat(controller-runtime): Implement stream controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,5 @@
 /nats-boot-config
 /nats-boot-config.docker
 /tools
+/bin
 /.idea

--- a/Makefile
+++ b/Makefile
@@ -202,6 +202,7 @@ $(ENVTEST): $(LOCALBIN)
 .PHONY: test
 test: envtest
 	go vet ./controllers/... ./pkg/natsreloader/... ./internal/controller/...
+	$(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path ## Get k8s binaries
 	go test -race -cover -count=1 -timeout 10s ./controllers/... ./pkg/natsreloader/... ./internal/controller/...
 
 .PHONY: clean

--- a/cmd/jetstream-controller/main.go
+++ b/cmd/jetstream-controller/main.go
@@ -88,16 +88,21 @@ func run() error {
 
 	if *controlLoop {
 		klog.Warning("Starting jetStream controller in experimental control loop mode")
+
 		natsCfg := &controller.NatsConfig{
 			CRDConnect:  *crdConnect,
 			ClientName:  "jetstream-controller",
 			Credentials: *creds,
 			NKey:        *nkey,
 			ServerURL:   *server,
-			CAs:         []string{*ca},
+			CAs:         []string{},
 			Certificate: *cert,
 			Key:         *key,
 			TLSFirst:    *tlsfirst,
+		}
+
+		if *ca != "" {
+			natsCfg.CAs = []string{*ca}
 		}
 
 		controllerCfg := &controller.Config{

--- a/cmd/jetstream-controller/main.go
+++ b/cmd/jetstream-controller/main.go
@@ -94,7 +94,7 @@ func run() error {
 			Credentials: *creds,
 			NKey:        *nkey,
 			ServerURL:   *server,
-			CA:          *ca,
+			CAs:         []string{*ca},
 			Certificate: *cert,
 			Key:         *key,
 			TLSFirst:    *tlsfirst,

--- a/controllers/jetstream/consumer.go
+++ b/controllers/jetstream/consumer.go
@@ -462,7 +462,7 @@ func setConsumerOK(ctx context.Context, s *apis.Consumer, i typed.ConsumerInterf
 	sc := s.DeepCopy()
 
 	sc.Status.ObservedGeneration = s.Generation
-	sc.Status.Conditions = upsertCondition(sc.Status.Conditions, apis.Condition{
+	sc.Status.Conditions = UpsertCondition(sc.Status.Conditions, apis.Condition{
 		Type:               readyCondType,
 		Status:             k8sapi.ConditionTrue,
 		LastTransitionTime: time.Now().UTC().Format(time.RFC3339Nano),
@@ -490,7 +490,7 @@ func setConsumerErrored(ctx context.Context, s *apis.Consumer, sif typed.Consume
 	}
 
 	sc := s.DeepCopy()
-	sc.Status.Conditions = upsertCondition(sc.Status.Conditions, apis.Condition{
+	sc.Status.Conditions = UpsertCondition(sc.Status.Conditions, apis.Condition{
 		Type:               readyCondType,
 		Status:             k8sapi.ConditionFalse,
 		LastTransitionTime: time.Now().UTC().Format(time.RFC3339Nano),

--- a/controllers/jetstream/controller.go
+++ b/controllers/jetstream/controller.go
@@ -495,7 +495,7 @@ func processQueueNext(q workqueue.RateLimitingInterface, jmsClient jsmClientFunc
 	q.Forget(item)
 }
 
-func upsertCondition(cs []apis.Condition, next apis.Condition) []apis.Condition {
+func UpsertCondition(cs []apis.Condition, next apis.Condition) []apis.Condition {
 	for i := 0; i < len(cs); i++ {
 		if cs[i].Type != next.Type {
 			continue

--- a/controllers/jetstream/controller_test.go
+++ b/controllers/jetstream/controller_test.go
@@ -186,7 +186,7 @@ func TestUpsertCondition(t *testing.T) {
 
 	var cs []apis.Condition
 
-	cs = upsertCondition(cs, apis.Condition{
+	cs = UpsertCondition(cs, apis.Condition{
 		Type:               readyCondType,
 		Status:             k8sapis.ConditionTrue,
 		LastTransitionTime: time.Now().UTC().Format(time.RFC3339Nano),
@@ -202,7 +202,7 @@ func TestUpsertCondition(t *testing.T) {
 		t.Fatalf("got=%s; want=%s", got, want)
 	}
 
-	cs = upsertCondition(cs, apis.Condition{
+	cs = UpsertCondition(cs, apis.Condition{
 		Type:               readyCondType,
 		Status:             k8sapis.ConditionFalse,
 		LastTransitionTime: time.Now().UTC().Format(time.RFC3339Nano),
@@ -218,7 +218,7 @@ func TestUpsertCondition(t *testing.T) {
 		t.Fatalf("got=%s; want=%s", got, want)
 	}
 
-	cs = upsertCondition(cs, apis.Condition{
+	cs = UpsertCondition(cs, apis.Condition{
 		Type:               "Foo",
 		Status:             k8sapis.ConditionTrue,
 		LastTransitionTime: time.Now().UTC().Format(time.RFC3339Nano),

--- a/controllers/jetstream/stream.go
+++ b/controllers/jetstream/stream.go
@@ -571,7 +571,7 @@ func setStreamErrored(ctx context.Context, s *apis.Stream, sif typed.StreamInter
 	}
 
 	sc := s.DeepCopy()
-	sc.Status.Conditions = upsertCondition(sc.Status.Conditions, apis.Condition{
+	sc.Status.Conditions = UpsertCondition(sc.Status.Conditions, apis.Condition{
 		Type:               readyCondType,
 		Status:             k8sapi.ConditionFalse,
 		LastTransitionTime: time.Now().UTC().Format(time.RFC3339Nano),
@@ -600,7 +600,7 @@ func setStreamOK(ctx context.Context, s *apis.Stream, i typed.StreamInterface) (
 	sc := s.DeepCopy()
 
 	sc.Status.ObservedGeneration = s.Generation
-	sc.Status.Conditions = upsertCondition(sc.Status.Conditions, apis.Condition{
+	sc.Status.Conditions = UpsertCondition(sc.Status.Conditions, apis.Condition{
 		Type:               readyCondType,
 		Status:             k8sapi.ConditionTrue,
 		LastTransitionTime: time.Now().UTC().Format(time.RFC3339Nano),

--- a/internal/controller/account_controller.go
+++ b/internal/controller/account_controller.go
@@ -18,21 +18,15 @@ package controller
 
 import (
 	"context"
-	"github.com/nats-io/nats.go/jetstream"
 	"k8s.io/klog/v2"
 
 	jetstreamnatsiov1beta2 "github.com/nats-io/nack/pkg/jetstream/apis/jetstream/v1beta2"
-	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // AccountReconciler reconciles a Account object
 type AccountReconciler struct {
-	client.Client
-	Scheme    *runtime.Scheme
-	Config    *Config
-	JetStream jetstream.JetStream
+	JetStreamController
 }
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to

--- a/internal/controller/account_controller.go
+++ b/internal/controller/account_controller.go
@@ -42,7 +42,7 @@ type AccountReconciler struct {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.17.3/pkg/reconcile
 func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := klog.FromContext(ctx)
-	log.Info("reconcile %s", "namespace", req.Namespace, "name", req.Name)
+	log.Info("reconcile", "namespace", req.Namespace, "name", req.Name)
 
 	// TODO(user): your logic here
 

--- a/internal/controller/account_controller.go
+++ b/internal/controller/account_controller.go
@@ -42,7 +42,7 @@ type AccountReconciler struct {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.17.3/pkg/reconcile
 func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := klog.FromContext(ctx)
-	log.Info("reconcile", "namespace", req.Namespace, "name", req.Name)
+	log.Info("reconcile %s", "namespace", req.Namespace, "name", req.Name)
 
 	// TODO(user): your logic here
 

--- a/internal/controller/account_controller_test.go
+++ b/internal/controller/account_controller_test.go
@@ -69,8 +69,7 @@ var _ = Describe("Account Controller", func() {
 		It("should successfully reconcile the resource", func() {
 			By("Reconciling the created resource")
 			controllerReconciler := &AccountReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				baseController,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{

--- a/internal/controller/client.go
+++ b/internal/controller/client.go
@@ -54,11 +54,18 @@ func (o *NatsConfig) buildOptions() ([]nats.Option, error) {
 	return opts, nil
 }
 
-func CreateJetStreamClient(cfg *NatsConfig, pedantic bool) (jetstream.JetStream, error) {
+type Closable interface {
+	Close()
+}
+
+// CreateJetStreamClient creates new Jetstream client with a connection based on the given NatsConfig.
+// Returns a jetstream.Jetstream client and the Closable of the underlying connection.
+// Close should be called when the client is no longer used.
+func CreateJetStreamClient(cfg *NatsConfig, pedantic bool) (jetstream.JetStream, Closable, error) {
 
 	opts, err := cfg.buildOptions()
 	if err != nil {
-		return nil, fmt.Errorf("nats options: %w", err)
+		return nil, nil, fmt.Errorf("nats options: %w", err)
 	}
 
 	// Set pedantic option
@@ -74,12 +81,12 @@ func CreateJetStreamClient(cfg *NatsConfig, pedantic bool) (jetstream.JetStream,
 
 	nc, err := nats.Connect(cfg.ServerURL, opts...)
 	if err != nil {
-		return nil, fmt.Errorf("nats connect: %w", err)
+		return nil, nil, fmt.Errorf("nats connect: %w", err)
 	}
 
 	js, err := jetstream.New(nc)
 	if err != nil {
-		return nil, fmt.Errorf("new jetstream: %w", err)
+		return nil, nil, fmt.Errorf("new jetstream: %w", err)
 	}
-	return js, nil
+	return js, nc, nil
 }

--- a/internal/controller/client.go
+++ b/internal/controller/client.go
@@ -12,7 +12,7 @@ type NatsConfig struct {
 	Credentials string
 	NKey        string
 	ServerURL   string
-	CA          string
+	CAs         []string
 	Certificate string
 	Key         string
 	TLSFirst    bool
@@ -46,8 +46,8 @@ func (o *NatsConfig) buildOptions() ([]nats.Option, error) {
 			opts = append(opts, nats.ClientCert(o.Certificate, o.Key))
 		}
 
-		if o.CA != "" {
-			opts = append(opts, nats.RootCAs(o.CA))
+		if o.CAs != nil && len(o.CAs) > 0 {
+			opts = append(opts, nats.RootCAs(o.CAs...))
 		}
 	}
 

--- a/internal/controller/consumer_controller.go
+++ b/internal/controller/consumer_controller.go
@@ -18,21 +18,15 @@ package controller
 
 import (
 	"context"
-	"github.com/nats-io/nats.go/jetstream"
 	"k8s.io/klog/v2"
 
 	jetstreamnatsiov1beta2 "github.com/nats-io/nack/pkg/jetstream/apis/jetstream/v1beta2"
-	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // ConsumerReconciler reconciles a Consumer object
 type ConsumerReconciler struct {
-	client.Client
-	Scheme    *runtime.Scheme
-	Config    *Config
-	JetStream jetstream.JetStream
+	JetStreamController
 }
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to

--- a/internal/controller/consumer_controller.go
+++ b/internal/controller/consumer_controller.go
@@ -19,12 +19,13 @@ package controller
 import (
 	"context"
 	"github.com/nats-io/nats.go/jetstream"
-	"k8s.io/klog/v2"
 
-	jetstreamnatsiov1beta2 "github.com/nats-io/nack/pkg/jetstream/apis/jetstream/v1beta2"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	jetstreamnatsiov1beta2 "github.com/nats-io/nack/pkg/jetstream/apis/jetstream/v1beta2"
 )
 
 // ConsumerReconciler reconciles a Consumer object
@@ -41,8 +42,9 @@ type ConsumerReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.17.3/pkg/reconcile
 func (r *ConsumerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := klog.FromContext(ctx)
-	log.Info("reconcile", "namespace", req.Namespace, "name", req.Name)
+	_ = log.FromContext(ctx)
+
+	// TODO(user): your logic here
 
 	return ctrl.Result{}, nil
 }

--- a/internal/controller/consumer_controller.go
+++ b/internal/controller/consumer_controller.go
@@ -19,13 +19,12 @@ package controller
 import (
 	"context"
 	"github.com/nats-io/nats.go/jetstream"
+	"k8s.io/klog/v2"
 
+	jetstreamnatsiov1beta2 "github.com/nats-io/nack/pkg/jetstream/apis/jetstream/v1beta2"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
-
-	jetstreamnatsiov1beta2 "github.com/nats-io/nack/pkg/jetstream/apis/jetstream/v1beta2"
 )
 
 // ConsumerReconciler reconciles a Consumer object
@@ -42,9 +41,8 @@ type ConsumerReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.17.3/pkg/reconcile
 func (r *ConsumerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	_ = log.FromContext(ctx)
-
-	// TODO(user): your logic here
+	log := klog.FromContext(ctx)
+	log.Info("reconcile %s", "namespace", req.Namespace, "name", req.Name)
 
 	return ctrl.Result{}, nil
 }

--- a/internal/controller/consumer_controller.go
+++ b/internal/controller/consumer_controller.go
@@ -42,7 +42,7 @@ type ConsumerReconciler struct {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.17.3/pkg/reconcile
 func (r *ConsumerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := klog.FromContext(ctx)
-	log.Info("reconcile %s", "namespace", req.Namespace, "name", req.Name)
+	log.Info("reconcile", "namespace", req.Namespace, "name", req.Name)
 
 	return ctrl.Result{}, nil
 }

--- a/internal/controller/consumer_controller_test.go
+++ b/internal/controller/consumer_controller_test.go
@@ -75,8 +75,7 @@ var _ = Describe("Consumer Controller", func() {
 		It("should successfully reconcile the resource", func() {
 			By("Reconciling the created resource")
 			controllerReconciler := &ConsumerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				baseController,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{

--- a/internal/controller/helpers_test.go
+++ b/internal/controller/helpers_test.go
@@ -1,0 +1,43 @@
+package controller
+
+import (
+	api "github.com/nats-io/nack/pkg/jetstream/apis/jetstream/v1beta2"
+	"github.com/nats-io/nats-server/v2/server"
+	natsserver "github.com/nats-io/nats-server/v2/test"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+
+	"os"
+	"time"
+)
+
+func assertReadyStateMatches(condition api.Condition, status v1.ConditionStatus, reason string, message string, transitionTime time.Time) {
+	GinkgoHelper()
+
+	Expect(condition.Type).To(Equal(readyCondType))
+	Expect(condition.Status).To(Equal(status))
+	Expect(condition.Reason).To(Equal(reason))
+	Expect(condition.Message).To(ContainSubstring(message))
+
+	// Assert valid transition time
+	t, err := time.Parse(time.RFC3339Nano, condition.LastTransitionTime)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(t).To(BeTemporally("~", transitionTime, time.Second))
+}
+
+func CreateTestServer() *server.Server {
+	opts := &natsserver.DefaultTestOptions
+	opts.JetStream = true
+	opts.Port = -1
+	opts.Debug = true
+
+	dir, err := os.MkdirTemp("", "nats-*")
+	Expect(err).NotTo(HaveOccurred())
+	opts.StoreDir = dir
+
+	ns := natsserver.RunServer(opts)
+	Expect(err).NotTo(HaveOccurred())
+
+	return ns
+}

--- a/internal/controller/jetstream_controller.go
+++ b/internal/controller/jetstream_controller.go
@@ -135,4 +135,8 @@ func updateReadyCondition(conditions []api.Condition, status v1.ConditionStatus,
 		return js.UpsertCondition(conditions, newCondition)
 	}
 
+// asJsonString returns the given string wrapped in " and converted to []byte.
+// Helper for mapping spec config to jetStream config using UnmarshalJSON.
+func asJsonString(v string) []byte {
+	return []byte("\"" + v + "\"")
 }

--- a/internal/controller/jetstream_controller.go
+++ b/internal/controller/jetstream_controller.go
@@ -1,0 +1,123 @@
+package controller
+
+import (
+	"errors"
+	"fmt"
+	js "github.com/nats-io/nack/controllers/jetstream"
+	api "github.com/nats-io/nack/pkg/jetstream/apis/jetstream/v1beta2"
+	"github.com/nats-io/nats.go/jetstream"
+	v1 "k8s.io/api/core/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"time"
+)
+
+type connectionOptions struct {
+	Account string   `json:"account"`
+	Creds   string   `json:"creds"`
+	Nkey    string   `json:"nkey"`
+	Servers []string `json:"servers"`
+	TLS     api.TLS  `json:"tls"`
+}
+
+func (o connectionOptions) empty() bool {
+	return o.Account == "" &&
+		o.Creds == "" &&
+		o.Nkey == "" &&
+		len(o.Servers) == 0 &&
+		o.TLS.ClientCert == "" &&
+		o.TLS.ClientKey == "" &&
+		len(o.TLS.RootCAs) == 0
+}
+
+type JetStreamController interface {
+	client.Client
+
+	// ReadOnly returns true when this controller
+	readOnly() bool
+	Namespace() string
+	WithJetStreamClient(*connectionOptions, func(js jetstream.JetStream) error) error
+}
+
+func NewJSController(k8sClient client.Client, natsConfig *NatsConfig, controllerConfig *Config) (JetStreamController, error) {
+
+	var baseClient jetstream.JetStream
+	if natsConfig.ServerURL != "" {
+		var err error
+		baseClient, _, err = CreateJetStreamClient(natsConfig, true)
+		if err != nil {
+			return nil, fmt.Errorf("create base js k8sClient: %w", err)
+		}
+	}
+
+	return &jsController{
+		Client:           k8sClient,
+		config:           natsConfig,
+		controllerConfig: controllerConfig,
+		baseClient:       baseClient,
+	}, nil
+}
+
+type jsController struct {
+	client.Client
+	config           *NatsConfig
+	controllerConfig *Config
+	baseClient       jetstream.JetStream
+}
+
+func (c *jsController) readOnly() bool {
+	return c.controllerConfig.ReadOnly
+}
+
+func (c *jsController) Namespace() string {
+	return c.controllerConfig.Namespace
+}
+
+func (c *jsController) WithJetStreamClient(opts *connectionOptions, op func(js jetstream.JetStream) error) error {
+	// TODO Handle Account, Nkey, Servers and TLS from spec.
+	// TODO Get specific client when there is connection config in the spec.
+
+	if c.baseClient == nil {
+		return errors.New("no client available")
+	}
+
+	if opts == nil || opts.empty() {
+		return op(c.baseClient)
+	}
+
+	// TODO Build single use client
+	return errors.New("Not Implemented")
+}
+
+// updateReadyCondition returns the conditions with an added or updated ready condition
+func updateReadyCondition(conditions []api.Condition, status v1.ConditionStatus, reason string, message string) []api.Condition {
+
+	var currentStatus v1.ConditionStatus
+	var lastTransitionTime string
+	for _, condition := range conditions {
+		if condition.Type == readyCondType {
+			currentStatus = condition.Status
+			lastTransitionTime = condition.LastTransitionTime
+			break
+		}
+	}
+
+	// Set transition time to now, when no previous ready condition or the status changed
+	if lastTransitionTime == "" || currentStatus != status {
+		lastTransitionTime = time.Now().UTC().Format(time.RFC3339Nano)
+	}
+
+	newCondition := api.Condition{
+		Type:               readyCondType,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		LastTransitionTime: lastTransitionTime,
+	}
+	if conditions == nil {
+		return []api.Condition{newCondition}
+	} else {
+		return js.UpsertCondition(conditions, newCondition)
+	}
+
+}

--- a/internal/controller/jetstream_controller.go
+++ b/internal/controller/jetstream_controller.go
@@ -87,8 +87,12 @@ func (c *jsController) buildNatsConfig(opts *connectionOptions) *NatsConfig {
 		CRDConnect: false,
 		ClientName: c.config.ClientName,
 		ServerURL:  or(serverUrls, c.config.ServerURL),
-		TLSFirst:   c.config.TLSFirst, // TODO(review): should this value depend on any opts? There is no TLSFirst in the spec
+		TLSFirst:   c.config.TLSFirst, // TODO(future-feature): expose TLSFirst in the spec config
 	}
+
+	// Note: The opts.Account value coming from the resource spec is currently not considered.
+	// creds/nkey are associated with an account, the account field might be redundant.
+	// See https://github.com/nats-io/nack/pull/211#pullrequestreview-2511111670
 
 	// Authentication either from opts or base config
 	if opts.Creds != "" || opts.Nkey != "" {

--- a/internal/controller/jetstream_controller.go
+++ b/internal/controller/jetstream_controller.go
@@ -27,7 +27,7 @@ type JetStreamController interface {
 	ReadOnly() bool
 
 	// ValidNamespace ok if the controllers namespace restriction allows the given namespace.
-	ValidNamespace(string string) bool
+	ValidNamespace(namespace string) bool
 
 	// WithJetStreamClient provides a jetStream client to the given operation.
 	// The client uses the controllers connection configuration merged with opts.
@@ -57,9 +57,9 @@ func (c *jsController) ReadOnly() bool {
 	return c.controllerConfig.ReadOnly
 }
 
-func (c *jsController) ValidNamespace(targetNamespace string) bool {
+func (c *jsController) ValidNamespace(namespace string) bool {
 	ns := c.controllerConfig.Namespace
-	return ns == "" || ns == targetNamespace
+	return ns == "" || ns == namespace
 }
 
 func (c *jsController) WithJetStreamClient(opts *connectionOptions, op func(js jetstream.JetStream) error) error {

--- a/internal/controller/jetstream_controller.go
+++ b/internal/controller/jetstream_controller.go
@@ -103,13 +103,18 @@ func (c *jsController) buildNatsConfig(opts *connectionOptions) *NatsConfig {
 		cfg.NKey = c.config.NKey
 	}
 
-	// Cert config either from opts or base config
-	if len(opts.TLS.RootCAs) > 0 || opts.TLS.ClientCert != "" || opts.TLS.ClientKey != "" {
+	// CAs from opts or base config
+	if len(opts.TLS.RootCAs) > 0 {
 		cfg.CAs = opts.TLS.RootCAs
+	} else {
+		cfg.CAs = c.config.CAs
+	}
+
+	// Client Cert and Key either from opts or base config
+	if opts.TLS.ClientCert != "" && opts.TLS.ClientKey != "" {
 		cfg.Certificate = opts.TLS.ClientCert
 		cfg.Key = opts.TLS.ClientKey
 	} else {
-		cfg.CAs = c.config.CAs
 		cfg.Certificate = c.config.Certificate
 		cfg.Key = c.config.Key
 	}

--- a/internal/controller/jetstream_controller_test.go
+++ b/internal/controller/jetstream_controller_test.go
@@ -1,0 +1,138 @@
+package controller
+
+import (
+	api "github.com/nats-io/nack/pkg/jetstream/apis/jetstream/v1beta2"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	"testing"
+	"time"
+)
+
+func Test_updateReadyCondition(t *testing.T) {
+
+	pastTransition := time.Now().UTC().Add(-time.Hour).Format(time.RFC3339Nano)
+	updatedTransition := "now"
+
+	otherCondition := api.Condition{
+		Type:               "other",
+		Status:             v1.ConditionFalse,
+		Reason:             "Reason",
+		Message:            "Message",
+		LastTransitionTime: pastTransition,
+	}
+
+	type args struct {
+		conditions []api.Condition
+		status     v1.ConditionStatus
+		reason     string
+		message    string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []api.Condition
+	}{
+		{
+			name: "new ready condition",
+			args: args{
+				conditions: nil,
+				status:     v1.ConditionTrue,
+				reason:     "Test",
+				message:    "Test Message",
+			},
+			want: []api.Condition{
+				{
+					Type:               readyCondType,
+					Status:             v1.ConditionTrue,
+					Reason:             "Test",
+					Message:            "Test Message",
+					LastTransitionTime: updatedTransition,
+				},
+			},
+		},
+		{
+			name: "update ready condition",
+			args: args{
+				conditions: []api.Condition{
+					otherCondition,
+					{
+						Type:               readyCondType,
+						Status:             v1.ConditionFalse,
+						Reason:             "Test",
+						Message:            "Test Message",
+						LastTransitionTime: pastTransition,
+					},
+				},
+				status:  v1.ConditionTrue,
+				reason:  "New Reason",
+				message: "New Message",
+			},
+			want: []api.Condition{
+				otherCondition,
+				{
+					Type:               readyCondType,
+					Status:             v1.ConditionTrue,
+					Reason:             "New Reason",
+					Message:            "New Message",
+					LastTransitionTime: updatedTransition,
+				},
+			},
+		},
+		{
+			name: "should not update transition time when status is not changed",
+			args: args{
+				conditions: []api.Condition{
+					otherCondition,
+					{
+						Type:               readyCondType,
+						Status:             v1.ConditionTrue,
+						Reason:             "Test",
+						Message:            "Test Message",
+						LastTransitionTime: pastTransition,
+					},
+				},
+				status:  v1.ConditionTrue,
+				reason:  "New Reason",
+				message: "New Message",
+			},
+			want: []api.Condition{
+				otherCondition,
+				{
+					Type:               readyCondType,
+					Status:             v1.ConditionTrue,
+					Reason:             "New Reason",
+					Message:            "New Message",
+					LastTransitionTime: pastTransition,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			got := updateReadyCondition(tt.args.conditions, tt.args.status, tt.args.reason, tt.args.message)
+
+			assert.Len(got, len(tt.want))
+			for i, want := range tt.want {
+				actual := got[i]
+
+				assert.Equal(actual.Type, want.Type)
+				assert.Equal(actual.Status, want.Status)
+				assert.Equal(actual.Reason, want.Reason)
+				assert.Equal(actual.Message, want.Message)
+
+				// Assert transition time was updated
+				if want.LastTransitionTime == updatedTransition {
+					actualTransitionTime, err := time.Parse(time.RFC3339Nano, actual.LastTransitionTime)
+					assert.NoError(err)
+					assert.WithinDuration(actualTransitionTime, time.Now(), 5*time.Second)
+				}
+				// Assert transition time was not updated
+				if want.LastTransitionTime == pastTransition {
+					assert.Equal(pastTransition, actual.LastTransitionTime)
+				}
+			}
+		})
+	}
+}

--- a/internal/controller/stream_controller.go
+++ b/internal/controller/stream_controller.go
@@ -366,11 +366,6 @@ func mapStreamSource(ss *api.StreamSource) (*jetstream.StreamSource, error) {
 	return jss, nil
 }
 
-// asJsonString returns the given string wrapped in " and converted to []byte.
-func asJsonString(v string) []byte {
-	return []byte("\"" + v + "\"")
-}
-
 // SetupWithManager sets up the controller with the Manager.
 func (r *StreamReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/stream_controller.go
+++ b/internal/controller/stream_controller.go
@@ -192,12 +192,12 @@ func (r *StreamReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return err
 	})
 	if err != nil {
-		msg := fmt.Sprintf("create or update stream: %s", err.Error())
-		stream.Status.Conditions = updateReadyCondition(stream.Status.Conditions, v1.ConditionFalse, "Errored", msg)
+		err = fmt.Errorf("create or update stream: %w", err)
+		stream.Status.Conditions = updateReadyCondition(stream.Status.Conditions, v1.ConditionFalse, "Errored", err.Error())
 		if err := r.Status().Update(ctx, stream); err != nil {
 			log.Error(err, "failed to update ready condition to Errored")
 		}
-		return ctrl.Result{}, fmt.Errorf("create or update stream: %w", err)
+		return ctrl.Result{}, err
 	}
 
 	// update the observed generation and ready status

--- a/internal/controller/stream_controller.go
+++ b/internal/controller/stream_controller.go
@@ -137,7 +137,9 @@ func (r *StreamReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			err := r.WithJetStreamClient(specConnectionOptions, func(js jetstream.JetStream) error {
 				return js.DeleteStream(ctx, stream.Spec.Name)
 			})
-			if err != nil {
+			if errors.Is(err, jetstream.ErrStreamNotFound) {
+				log.Info("managed stream was already deleted")
+			} else if err != nil {
 				return ctrl.Result{}, fmt.Errorf("delete stream during finalization: %w", err)
 			}
 		}

--- a/internal/controller/stream_controller.go
+++ b/internal/controller/stream_controller.go
@@ -180,8 +180,8 @@ func (r *StreamReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, fmt.Errorf("create or update stream: %w", err)
 	}
 
-	// TODO update the generation in the status
-
+	// update the observed generation and ready status
+	stream.Status.ObservedGeneration = stream.Generation
 	stream.Status.Conditions = updateReadyCondition(
 		stream.Status.Conditions,
 		v1.ConditionTrue,

--- a/internal/controller/stream_controller.go
+++ b/internal/controller/stream_controller.go
@@ -18,13 +18,20 @@ package controller
 
 import (
 	"context"
+	"fmt"
+	js "github.com/nats-io/nack/controllers/jetstream"
+	api "github.com/nats-io/nack/pkg/jetstream/apis/jetstream/v1beta2"
 	"github.com/nats-io/nats.go/jetstream"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	jetstreamnatsiov1beta2 "github.com/nats-io/nack/pkg/jetstream/apis/jetstream/v1beta2"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"time"
 )
 
 // StreamReconciler reconciles a Stream object
@@ -41,16 +48,364 @@ type StreamReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.17.3/pkg/reconcile
 func (r *StreamReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := klog.FromContext(ctx)
-	log.Info("reconcile", "namespace", req.Namespace, "name", req.Name)
-	// TODO(user): your logic here
+	log := klog.FromContext(ctx).
+		WithName("StreamReconciler").
+		WithValues("namespace", req.Namespace, "name", req.Name)
+
+	log.Info("reconciling")
+
+	// TODO honour r.Config.ReadOnly and r.Config.Namespace
+
+	// Fetch stream resource
+	stream := &api.Stream{}
+	if err := r.Get(ctx, req.NamespacedName, stream); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("stream resource not found. Ignoring since object must be deleted")
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("get stream resource '%s': %w", req.NamespacedName.String(), err)
+	}
+
+	// Add finalizer
+	if !controllerutil.ContainsFinalizer(stream, streamFinalizer) {
+		log.Info("Adding stream finalizer")
+		if ok := controllerutil.AddFinalizer(stream, streamFinalizer); !ok {
+			log.Error(nil, "Failed to add finalizer to stream resource")
+			return ctrl.Result{Requeue: true}, nil
+		}
+
+		if err := r.Update(ctx, stream); err != nil {
+			return ctrl.Result{}, fmt.Errorf("update stream resource to add finalizer: %w", err)
+		}
+
+		// re-fetch stream
+		if err := r.Get(ctx, req.NamespacedName, stream); err != nil {
+			if apierrors.IsNotFound(err) {
+				log.Info("stream resource not found. Ignoring since object must be deleted")
+				return ctrl.Result{}, nil
+			}
+			return ctrl.Result{}, fmt.Errorf("re-fetch stream resource: %w", err)
+		}
+	}
+
+	// Update Status to unknown when no status is set
+	if stream.Status.Conditions == nil || len(stream.Status.Conditions) == 0 {
+		updated, err := r.updateReadyCondition(ctx, stream, v1.ConditionUnknown, "Reconciling", "Starting reconciliation")
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("set condition unknown: %w", err)
+		}
+		if updated {
+			// re-fetch stream
+			if err := r.Get(ctx, req.NamespacedName, stream); err != nil {
+				if apierrors.IsNotFound(err) {
+					log.Info("stream resource not found. Ignoring since object must be deleted")
+					return ctrl.Result{}, nil
+				}
+				return ctrl.Result{}, fmt.Errorf("re-fetch stream resource: %w", err)
+			}
+		}
+
+	}
+
+	// TODO Check if marked for deletion and delete
+	// TODO honour stream.Spec.PreventDelete and
+
+	// Create or Update the stream based on the spec
+
+	// Map spec to stream targetConfig
+	targetConfig, err := mapSpecToConfig(&stream.Spec)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("map spec to stream targetConfig: %w", err)
+	}
+
+	// TODO Handle Account, Nkey, Servers and TLS from spec.
+	// TODO Get specific client when there is connection config in the spec.
+	var sm jetstream.StreamManager
+	sm = r.JetStream
+
+	//  TODO honour stream.Spec.PreventUpdate
+	_, err = sm.CreateOrUpdateStream(ctx, targetConfig)
+	if err != nil {
+		_, conditionErr := r.updateReadyCondition(ctx, stream, v1.ConditionFalse, "Errored", fmt.Sprintf("create or update stream: %s", err.Error()))
+		if conditionErr != nil {
+			log.Error(conditionErr, "failed to update ready condition to CreationFailed")
+		}
+		return ctrl.Result{}, fmt.Errorf("create or update stream: %w", err)
+	}
+
+	// TODO update the generation in the status
+
+	_, err = r.updateReadyCondition(ctx, stream, v1.ConditionTrue, "Reconciling", "Stream successfully created or updated")
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("update ready condition: %w", err)
+	}
 
 	return ctrl.Result{}, nil
+}
+
+// updateReadyCondition sets the status, reason and message.
+// Then updates the resource.
+// Returns true if the resource was updated by this call.
+func (r *StreamReconciler) updateReadyCondition(ctx context.Context, stream *api.Stream, status v1.ConditionStatus, reason string, message string) (bool, error) {
+
+	newCondition := api.Condition{
+		Type:               readyCondType,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		LastTransitionTime: time.Now().UTC().Format(time.RFC3339Nano),
+	}
+
+	// Mapping to and from the metav1.Condition allows using meta.SetStatusCondition,
+	// which properly handles updating conditions.
+	// The mapping happens transparently to the caller.
+
+	cond := mapConditionToMeta(newCondition)
+	var conditions []metav1.Condition
+	for _, condition := range stream.Status.Conditions {
+		conditions = append(conditions, mapConditionToMeta(condition))
+	}
+
+	changed := meta.SetStatusCondition(&conditions, cond)
+	if !changed {
+		return false, nil
+	}
+
+	stream.Status.Conditions = []api.Condition{}
+	for _, condition := range conditions {
+		stream.Status.Conditions = append(stream.Status.Conditions, mapConditionFromMeta(condition))
+	}
+
+	stream.Status.Conditions = js.UpsertCondition(stream.Status.Conditions, newCondition)
+
+	if err := r.Status().Update(ctx, stream); err != nil {
+		return false, fmt.Errorf("update stream status: %w", err)
+	}
+	return true, nil
+}
+
+// mapConditionToMeta transforms a condition according the jetstream v1beta2 spec to a metav1 condition.
+func mapConditionToMeta(condition api.Condition) metav1.Condition {
+
+	status := metav1.ConditionUnknown
+	switch condition.Status {
+	case v1.ConditionTrue:
+		status = metav1.ConditionTrue
+	case v1.ConditionFalse:
+		status = metav1.ConditionFalse
+	}
+
+	lastTransitionTime, err := time.Parse(time.RFC3339Nano, condition.LastTransitionTime)
+	if err != nil {
+		lastTransitionTime = time.Time{}
+	}
+
+	return metav1.Condition{
+		Type:               condition.Type,
+		Status:             status,
+		LastTransitionTime: metav1.NewTime(lastTransitionTime),
+		Reason:             condition.Reason,
+		Message:            condition.Message,
+	}
+}
+
+// mapConditionFromMeta transforms a condition according the metav1 spec to a jetstream v1beta2 condition
+func mapConditionFromMeta(condition metav1.Condition) api.Condition {
+
+	status := v1.ConditionUnknown
+	switch condition.Status {
+	case metav1.ConditionTrue:
+		status = v1.ConditionTrue
+	case metav1.ConditionFalse:
+		status = v1.ConditionFalse
+	}
+
+	lastTransitionTime := condition.LastTransitionTime.Format(time.RFC3339Nano)
+
+	return api.Condition{
+		Type:               condition.Type,
+		Status:             status,
+		LastTransitionTime: lastTransitionTime,
+		Reason:             condition.Reason,
+		Message:            condition.Message,
+	}
+}
+
+// mapSpecToConfig creates a jetstream.StreamConfig matching the given stream resource spec
+func mapSpecToConfig(spec *api.StreamSpec) (jetstream.StreamConfig, error) {
+
+	// Set directly mapped fields
+	config := jetstream.StreamConfig{
+		Name:                 spec.Name,
+		Description:          spec.Description,
+		Subjects:             spec.Subjects,
+		MaxConsumers:         spec.MaxConsumers,
+		MaxMsgs:              int64(spec.MaxMsgs),
+		MaxBytes:             int64(spec.MaxBytes),
+		DiscardNewPerSubject: spec.DiscardPerSubject,
+		MaxMsgsPerSubject:    int64(spec.MaxMsgsPerSubject),
+		MaxMsgSize:           int32(spec.MaxMsgSize),
+		Replicas:             spec.Replicas,
+		NoAck:                spec.NoAck,
+		DenyDelete:           spec.DenyDelete,
+		DenyPurge:            spec.DenyPurge,
+		AllowRollup:          spec.AllowRollup,
+		FirstSeq:             spec.FirstSequence,
+		AllowDirect:          spec.AllowDirect,
+		// Explicitly set not (yet) mapped fields
+		Sealed:         false,
+		MirrorDirect:   false,
+		ConsumerLimits: jetstream.StreamConsumerLimits{},
+	}
+
+	// Set not directly mapped fields
+
+	// retention
+	if spec.Retention != "" {
+		// Wrap string in " to be properly unmarshalled as json string
+		err := config.Retention.UnmarshalJSON(asJsonString(spec.Retention))
+		if err != nil {
+			return jetstream.StreamConfig{}, fmt.Errorf("invalid retention policy: %w", err)
+		}
+	}
+
+	// discard
+	if spec.Discard != "" {
+		err := config.Discard.UnmarshalJSON(asJsonString(spec.Discard))
+		if err != nil {
+			return jetstream.StreamConfig{}, fmt.Errorf("invalid retention policy: %w", err)
+		}
+	}
+
+	// maxAge
+	if spec.MaxAge != "" {
+		d, err := time.ParseDuration(spec.MaxAge)
+		if err != nil {
+			return jetstream.StreamConfig{}, fmt.Errorf("parse max age: %w", err)
+		}
+		config.MaxAge = d
+	}
+	// storage
+	if spec.Storage != "" {
+		err := config.Storage.UnmarshalJSON(asJsonString(spec.Storage))
+		if err != nil {
+			return jetstream.StreamConfig{}, fmt.Errorf("invalid storage: %w", err)
+		}
+	}
+
+	// duplicates
+	if spec.DuplicateWindow != "" {
+		d, err := time.ParseDuration(spec.DuplicateWindow)
+		if err != nil {
+			return jetstream.StreamConfig{}, fmt.Errorf("parse duplicate window: %w", err)
+		}
+		config.Duplicates = d
+	}
+
+	// placement
+	if spec.Placement != nil {
+		config.Placement = &jetstream.Placement{
+			Cluster: spec.Placement.Cluster,
+			Tags:    spec.Placement.Tags,
+		}
+	}
+
+	// mirror
+	if spec.Mirror != nil {
+		ss, err := mapStreamSource(spec.Mirror)
+		if err != nil {
+			return jetstream.StreamConfig{}, fmt.Errorf("map mirror stream soruce: %w", err)
+		}
+		config.Mirror = ss
+	}
+
+	// sources
+	if spec.Sources != nil {
+		config.Sources = []*jetstream.StreamSource{}
+		for _, source := range spec.Sources {
+			s, err := mapStreamSource(source)
+			if err != nil {
+				return jetstream.StreamConfig{}, fmt.Errorf("map stream soruce: %w", err)
+			}
+			config.Sources = append(config.Sources, s)
+		}
+	}
+
+	// compression
+	if spec.Compression != "" {
+		err := config.Compression.UnmarshalJSON(asJsonString(spec.Compression))
+		if err != nil {
+			return jetstream.StreamConfig{}, fmt.Errorf("invalid compression: %w", err)
+		}
+	}
+
+	// subjectTransform
+	if spec.SubjectTransform != nil {
+		config.SubjectTransform = &jetstream.SubjectTransformConfig{
+			Source:      spec.SubjectTransform.Source,
+			Destination: spec.SubjectTransform.Dest,
+		}
+	}
+
+	// rePublish
+	if spec.Republish != nil {
+		config.RePublish = &jetstream.RePublish{
+			Source:      spec.Republish.Source,
+			Destination: spec.Republish.Destination,
+			HeadersOnly: spec.Republish.HeadersOnly,
+		}
+	}
+
+	// metadata
+	if spec.Metadata != nil {
+		config.Metadata = spec.Metadata
+	}
+
+	return config, nil
+}
+
+func mapStreamSource(ss *api.StreamSource) (*jetstream.StreamSource, error) {
+	jss := &jetstream.StreamSource{
+		Name:          ss.Name,
+		FilterSubject: ss.FilterSubject,
+	}
+
+	if ss.OptStartSeq > 0 {
+		jss.OptStartSeq = uint64(ss.OptStartSeq)
+	}
+	if ss.OptStartTime != "" {
+		t, err := time.Parse(time.RFC3339, ss.OptStartTime)
+		if err != nil {
+			return nil, fmt.Errorf("parse opt start time: %w", err)
+		}
+		jss.OptStartTime = &t
+	}
+
+	if ss.ExternalAPIPrefix != "" || ss.ExternalDeliverPrefix != "" {
+		jss.External = &jetstream.ExternalStream{
+			APIPrefix:     ss.ExternalAPIPrefix,
+			DeliverPrefix: ss.ExternalDeliverPrefix,
+		}
+	}
+
+	for _, transform := range ss.SubjectTransforms {
+		jss.SubjectTransforms = append(jss.SubjectTransforms, jetstream.SubjectTransformConfig{
+			Source:      transform.Source,
+			Destination: transform.Dest,
+		})
+	}
+
+	return jss, nil
+}
+
+// asJsonString returns the given string wrapped in " and converted to []byte.
+func asJsonString(v string) []byte {
+	return []byte("\"" + v + "\"")
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *StreamReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&jetstreamnatsiov1beta2.Stream{}).
+		For(&api.Stream{}).
 		Complete(r)
 }

--- a/internal/controller/stream_controller.go
+++ b/internal/controller/stream_controller.go
@@ -43,6 +43,7 @@ type StreamReconciler struct {
 func (r *StreamReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := klog.FromContext(ctx)
 	log.Info("reconcile %s", "namespace", req.Namespace, "name", req.Name)
+	// TODO(user): your logic here
 
 	return ctrl.Result{}, nil
 }

--- a/internal/controller/stream_controller.go
+++ b/internal/controller/stream_controller.go
@@ -202,7 +202,7 @@ func (r *StreamReconciler) createOrUpdate(ctx context.Context, log logr.Logger, 
 // streamConnOpts extracts nats connection relevant fields from the given stream spec as connectionOptions.
 func streamConnOpts(spec api.StreamSpec) *connectionOptions {
 	return &connectionOptions{
-		Account: spec.Account, // TODO(review): Where does Spec.Account have to be considered?
+		Account: spec.Account,
 		Creds:   spec.Creds,
 		Nkey:    spec.Nkey,
 		Servers: spec.Servers,

--- a/internal/controller/stream_controller.go
+++ b/internal/controller/stream_controller.go
@@ -152,7 +152,7 @@ func (r *StreamReconciler) deleteStream(ctx context.Context, log logr.Logger, st
 func (r *StreamReconciler) createOrUpdate(ctx context.Context, log logr.Logger, stream *api.Stream) error {
 
 	// Create or Update the stream based on the spec
-	if stream.Spec.PreventDelete || r.ReadOnly() {
+	if stream.Spec.PreventUpdate || r.ReadOnly() {
 		log.Info("Skipping stream creation or update.",
 			"streamName", stream.Spec.Name,
 			"preventDelete", stream.Spec.PreventDelete,

--- a/internal/controller/stream_controller.go
+++ b/internal/controller/stream_controller.go
@@ -42,8 +42,7 @@ type StreamReconciler struct {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.17.3/pkg/reconcile
 func (r *StreamReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := klog.FromContext(ctx)
-	log.Info("reconcile", "namespace", req.Namespace, "name", req.Name)
-	// TODO(user): your logic here
+	log.Info("reconcile %s", "namespace", req.Namespace, "name", req.Name)
 
 	return ctrl.Result{}, nil
 }

--- a/internal/controller/stream_controller.go
+++ b/internal/controller/stream_controller.go
@@ -126,7 +126,7 @@ func (r *StreamReconciler) deleteStream(ctx context.Context, log logr.Logger, st
 			return js.DeleteStream(ctx, stream.Spec.Name)
 		})
 		if errors.Is(err, jetstream.ErrStreamNotFound) {
-			log.Info("Managed stream was already deleted.")
+			log.Info("Stream does not exist, unable to delete.", "streamName", stream.Spec.Name)
 		} else if err != nil {
 			return fmt.Errorf("delete stream during finalization: %w", err)
 		}

--- a/internal/controller/stream_controller.go
+++ b/internal/controller/stream_controller.go
@@ -42,7 +42,7 @@ type StreamReconciler struct {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.17.3/pkg/reconcile
 func (r *StreamReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := klog.FromContext(ctx)
-	log.Info("reconcile %s", "namespace", req.Namespace, "name", req.Name)
+	log.Info("reconcile", "namespace", req.Namespace, "name", req.Name)
 	// TODO(user): your logic here
 
 	return ctrl.Result{}, nil

--- a/internal/controller/stream_controller.go
+++ b/internal/controller/stream_controller.go
@@ -66,6 +66,8 @@ func (r *StreamReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, fmt.Errorf("get stream resource '%s': %w", req.NamespacedName.String(), err)
 	}
 
+	log = log.WithValues("streamName", stream.Spec.Name)
+
 	// Update ready status to unknown when no status is set
 	if stream.Status.Conditions == nil || len(stream.Status.Conditions) == 0 {
 		log.Info("Setting initial ready condition to unknown.")
@@ -132,7 +134,6 @@ func (r *StreamReconciler) deleteStream(ctx context.Context, log logr.Logger, st
 		}
 	} else {
 		log.Info("Skipping stream deletion.",
-			"streamName", stream.Spec.Name,
 			"preventDelete", stream.Spec.PreventDelete,
 			"read-only", r.ReadOnly(),
 		)
@@ -154,7 +155,6 @@ func (r *StreamReconciler) createOrUpdate(ctx context.Context, log logr.Logger, 
 	// Create or Update the stream based on the spec
 	if stream.Spec.PreventUpdate || r.ReadOnly() {
 		log.Info("Skipping stream creation or update.",
-			"streamName", stream.Spec.Name,
 			"preventDelete", stream.Spec.PreventDelete,
 			"read-only", r.ReadOnly(),
 		)
@@ -170,7 +170,7 @@ func (r *StreamReconciler) createOrUpdate(ctx context.Context, log logr.Logger, 
 	// CreateOrUpdateStream is called on every reconciliation when the stream is not to be deleted.
 	// TODO(future-feature): Do we need to check if config differs?
 	err = r.WithJetStreamClient(streamConnOpts(stream.Spec), func(js jetstream.JetStream) error {
-		log.Info("create or update stream", "streamName", targetConfig.Name)
+		log.Info("Creating or updating stream.")
 		_, err = js.CreateOrUpdateStream(ctx, targetConfig)
 		return err
 	})

--- a/internal/controller/stream_controller_test.go
+++ b/internal/controller/stream_controller_test.go
@@ -122,6 +122,9 @@ var _ = Describe("Stream Controller", func() {
 			gotCondition.LastTransitionTime = ""
 			Expect(gotCondition).To(Equal(readyCondition))
 
+			By("Checking if the observed generation matches")
+			Expect(stream.Status.ObservedGeneration).To(Equal(stream.Generation))
+
 			By("Checking if the finalizer was set")
 			Expect(stream.Finalizers).To(ContainElement(streamFinalizer))
 
@@ -171,6 +174,9 @@ var _ = Describe("Stream Controller", func() {
 			// Unset LastTransitionTime to be equal for assertion
 			gotCondition.LastTransitionTime = ""
 			Expect(gotCondition).To(Equal(readyCondition))
+
+			By("Checking if the observed generation matches")
+			Expect(stream.Status.ObservedGeneration).To(Equal(stream.Generation))
 
 			By("Checking if the stream was updated")
 			natsStream, err := jsClient.Stream(ctx, streamName)
@@ -231,6 +237,9 @@ var _ = Describe("Stream Controller", func() {
 			Expect(cond.Reason).To(Equal("Errored"))
 			Expect(cond.Message).To(Equal("create or update stream: context deadline exceeded"))
 			Expect(cond.LastTransitionTime).NotTo(BeEmpty())
+
+			By("Checking if the observed generation does not match")
+			Expect(stream.Status.ObservedGeneration).ToNot(Equal(stream.Generation))
 
 			By("Checking if the finalizer was set")
 			Expect(stream.Finalizers).To(ContainElement(streamFinalizer))

--- a/internal/controller/stream_controller_test.go
+++ b/internal/controller/stream_controller_test.go
@@ -17,74 +17,425 @@ limitations under the License.
 package controller
 
 import (
+	"github.com/nats-io/nats.go/jetstream"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"testing"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	jetstreamnatsiov1beta2 "github.com/nats-io/nack/pkg/jetstream/apis/jetstream/v1beta2"
+	api "github.com/nats-io/nack/pkg/jetstream/apis/jetstream/v1beta2"
 )
 
 var _ = Describe("Stream Controller", func() {
-	Context("When reconciling a resource", func() {
-		const resourceName = "test-resource"
+	When("reconciling a resource", func() {
+		const resourceName = "test-stream"
 
 		typeNamespacedName := types.NamespacedName{
 			Name:      resourceName,
 			Namespace: "default", // TODO(user):Modify as needed
 		}
 
-		stream := &jetstreamnatsiov1beta2.Stream{}
+		stream := &api.Stream{}
 
 		BeforeEach(func(ctx SpecContext) {
 			By("creating the custom resource for the Kind Stream")
 			err := k8sClient.Get(ctx, typeNamespacedName, stream)
-			if err != nil && errors.IsNotFound(err) {
-				resource := &jetstreamnatsiov1beta2.Stream{
+			if err != nil && k8serrors.IsNotFound(err) {
+				resource := &api.Stream{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      resourceName,
 						Namespace: "default",
 					},
-					Spec: jetstreamnatsiov1beta2.StreamSpec{
-						Name:      "test-stream",
-						Replicas:  1,
-						Discard:   "old",
-						Storage:   "file",
-						Retention: "workqueue",
+					Spec: api.StreamSpec{
+						Name:        "test-stream",
+						Replicas:    1,
+						Subjects:    []string{"tests.*"},
+						Description: "test stream",
+						Retention:   "workqueue",
+						Discard:     "old",
+						Storage:     "file",
 					},
-
-					// TODO(user): Specify other spec details if needed.
 				}
 				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 			}
 		})
 
 		AfterEach(func(ctx SpecContext) {
-			// TODO(user): Cleanup logic after each test, like removing the resource instance.
-			resource := &jetstreamnatsiov1beta2.Stream{}
+			// Remove test stream resource
+			resource := &api.Stream{}
 			err := k8sClient.Get(ctx, typeNamespacedName, resource)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Cleanup the specific resource instance Stream")
 			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+
+			By("Deleting the stream")
+			err = jsClient.DeleteStream(ctx, resource.Spec.Name)
+			if err != nil {
+				Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
+			}
 		})
 
-		It("should successfully reconcile the resource", func(ctx SpecContext) {
+		It("should successfully create the stream", func(ctx SpecContext) {
 			By("Reconciling the created resource")
 			controllerReconciler := &StreamReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				Config:    &Config{},
+				JetStream: jsClient,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
 			Expect(err).NotTo(HaveOccurred())
-			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
-			// Example: If you expect a certain status condition after reconciliation, verify it here.
+
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Fetch resource
+			err = k8sClient.Get(ctx, typeNamespacedName, stream)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking if the ready state was updated")
+			readyCondition := api.Condition{
+				Type:    readyCondType,
+				Status:  v1.ConditionTrue,
+				Reason:  "Reconciling",
+				Message: "Stream successfully created or updated",
+			}
+			gotCondition := stream.Status.Conditions[0]
+			// Unset LastTransitionTime to be equal for assertion
+			gotCondition.LastTransitionTime = ""
+			Expect(gotCondition).To(Equal(readyCondition))
+
+			By("Checking if the finalizer was set")
+			Expect(stream.Finalizers).To(ContainElement(streamFinalizer))
+
+			By("Checking if the stream was created")
+			natsStream, err := jsClient.Stream(ctx, "test-stream")
+			Expect(err).NotTo(HaveOccurred())
+			streamInfo, err := natsStream.Info(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(streamInfo.Config.Name).To(Equal("test-stream"))
+			Expect(streamInfo.Created).To(BeTemporally("~", time.Now(), time.Second))
+		})
+
+		It("should successfully update the stream and update the status", func(ctx SpecContext) {
+
+			By("Creating the stream with empty subjects and description")
+			_, err := jsClient.CreateStream(ctx, jetstream.StreamConfig{
+				Name:      "test-stream",
+				Replicas:  1,
+				Retention: jetstream.WorkQueuePolicy,
+				Discard:   jetstream.DiscardOld,
+				Storage:   jetstream.FileStorage,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Reconciling the created resource")
+			controllerReconciler := &StreamReconciler{
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				Config:    &Config{},
+				JetStream: jsClient,
+			}
+
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Fetch resource
+			err = k8sClient.Get(ctx, typeNamespacedName, stream)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking if the ready state was updated")
+			readyCondition := api.Condition{
+				Type:    readyCondType,
+				Status:  v1.ConditionTrue,
+				Reason:  "Reconciling",
+				Message: "Stream successfully created or updated",
+			}
+			gotCondition := stream.Status.Conditions[0]
+			// Unset LastTransitionTime to be equal for assertion
+			gotCondition.LastTransitionTime = ""
+			Expect(gotCondition).To(Equal(readyCondition))
+
+			By("Checking if the stream was updated")
+			natsStream, err := jsClient.Stream(ctx, "test-stream")
+			Expect(err).NotTo(HaveOccurred())
+
+			streamInfo, err := natsStream.Info(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(streamInfo.Config.Description).To(Equal("test stream"))
+			Expect(streamInfo.Config.Subjects).To(Equal([]string{"tests.*"}))
+		})
+
+		It("should not fail on not existing resource", func(ctx SpecContext) {
+			By("Reconciling the created resource")
+			controllerReconciler := &StreamReconciler{
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				Config:    &Config{},
+				JetStream: jsClient,
+			}
+
+			result, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: "fake",
+					Name:      "not-existing",
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(ctrl.Result{}))
+		})
+
+		It("should set an error state, register finalizer and re-queue when the nats server is not available", func(ctx SpecContext) {
+			By("Reconciling the created resource")
+
+			// Setup client for not running server
+			sv := CreateTestServer()
+			js, err := CreateJetStreamClient(&NatsConfig{
+				ServerURL: sv.ClientURL(),
+			}, true)
+			Expect(err).NotTo(HaveOccurred())
+			sv.Shutdown()
+			// Is there an easier way to create a failing js client?
+
+			controllerReconciler := &StreamReconciler{
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				Config:    &Config{},
+				JetStream: js,
+			}
+
+			result, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(err).To(HaveOccurred()) // Will be re-queued with back-off
+
+			// Fetch resource
+			err = k8sClient.Get(ctx, typeNamespacedName, stream)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking if the status was updated")
+			Expect(stream.Status.Conditions).To(HaveLen(1))
+
+			cond := stream.Status.Conditions[0]
+			Expect(cond.Type).To(Equal(readyCondType))
+			Expect(cond.Status).To(Equal(v1.ConditionFalse))
+			Expect(cond.Reason).To(Equal("Errored"))
+			Expect(cond.Message).To(Equal("create or update stream: context deadline exceeded"))
+			Expect(cond.LastTransitionTime).NotTo(BeEmpty())
+
+			By("Checking if the finalizer was set")
+			Expect(stream.Finalizers).To(ContainElement(streamFinalizer))
+		})
+
+		PIt("should delete stream marked for deletion", func(ctx SpecContext) {
+
 		})
 	})
 })
+
+func Test_mapSpecToConfig(t *testing.T) {
+
+	date := time.Date(2024, 12, 03, 16, 55, 5, 0, time.UTC)
+	dateString := date.Format(time.RFC3339)
+
+	tests := []struct {
+		name    string
+		spec    *api.StreamSpec
+		want    jetstream.StreamConfig
+		wantErr bool
+	}{
+		{
+			name:    "emtpy spec",
+			spec:    &api.StreamSpec{},
+			want:    jetstream.StreamConfig{},
+			wantErr: false,
+		},
+		{
+			name: "full spec",
+			spec: &api.StreamSpec{
+				Account:           "",
+				AllowDirect:       true,
+				AllowRollup:       true,
+				Creds:             "",
+				DenyDelete:        true,
+				DenyPurge:         true,
+				Description:       "stream description",
+				DiscardPerSubject: true,
+				PreventDelete:     false,
+				PreventUpdate:     false,
+				Discard:           "new",
+				DuplicateWindow:   "5s",
+				MaxAge:            "30s",
+				MaxBytes:          -1,
+				MaxConsumers:      -1,
+				MaxMsgs:           -1,
+				MaxMsgSize:        -1,
+				MaxMsgsPerSubject: 10,
+				Mirror: &api.StreamSource{
+					Name:                  "mirror",
+					OptStartSeq:           5,
+					OptStartTime:          dateString,
+					FilterSubject:         "orders",
+					ExternalAPIPrefix:     "api",
+					ExternalDeliverPrefix: "deliver",
+					SubjectTransforms: []*api.SubjectTransform{{
+						Source: "transform-source",
+						Dest:   "transform-dest",
+					}},
+				},
+				Name:  "stream-name",
+				Nkey:  "",
+				NoAck: true,
+				Placement: &api.StreamPlacement{
+					Cluster: "test-cluster",
+					Tags:    []string{"tag"},
+				},
+				Replicas: 3,
+				Republish: &api.RePublish{
+					Source:      "re-publish-source",
+					Destination: "re-publish-dest",
+					HeadersOnly: true,
+				},
+				SubjectTransform: &api.SubjectTransform{
+					Source: "transform-source",
+					Dest:   "transform-dest",
+				},
+				FirstSequence: 42,
+				Compression:   "s2",
+				Metadata: map[string]string{
+					"meta": "data",
+				},
+				Retention: "interest",
+				Servers:   nil,
+				Sources: []*api.StreamSource{{
+					Name:                  "source",
+					OptStartSeq:           5,
+					OptStartTime:          dateString,
+					FilterSubject:         "orders",
+					ExternalAPIPrefix:     "api",
+					ExternalDeliverPrefix: "deliver",
+					SubjectTransforms: []*api.SubjectTransform{{
+						Source: "transform-source",
+						Dest:   "transform-dest",
+					}},
+				}},
+				Storage:  "file",
+				Subjects: []string{"orders.*"},
+				TLS:      api.TLS{},
+			},
+			want: jetstream.StreamConfig{
+				Name:                 "stream-name",
+				Description:          "stream description",
+				Subjects:             []string{"orders.*"},
+				Retention:            jetstream.InterestPolicy,
+				MaxConsumers:         -1,
+				MaxMsgs:              -1,
+				MaxBytes:             -1,
+				Discard:              jetstream.DiscardNew,
+				DiscardNewPerSubject: true,
+				MaxAge:               time.Second * 30,
+				MaxMsgsPerSubject:    10,
+				MaxMsgSize:           -1,
+				Storage:              jetstream.FileStorage,
+				Replicas:             3,
+				NoAck:                true,
+				Duplicates:           time.Second * 5,
+				Placement: &jetstream.Placement{
+					Cluster: "test-cluster",
+					Tags:    []string{"tag"},
+				},
+				Mirror: &jetstream.StreamSource{
+					Name:          "mirror",
+					OptStartSeq:   5,
+					OptStartTime:  &date,
+					FilterSubject: "orders",
+					SubjectTransforms: []jetstream.SubjectTransformConfig{{
+						Source:      "transform-source",
+						Destination: "transform-dest",
+					}},
+					External: &jetstream.ExternalStream{
+						APIPrefix:     "api",
+						DeliverPrefix: "deliver",
+					},
+					Domain: "",
+				},
+				Sources: []*jetstream.StreamSource{{
+					Name:          "source",
+					OptStartSeq:   5,
+					OptStartTime:  &date,
+					FilterSubject: "orders",
+					SubjectTransforms: []jetstream.SubjectTransformConfig{{
+						Source:      "transform-source",
+						Destination: "transform-dest",
+					}},
+					External: &jetstream.ExternalStream{
+						APIPrefix:     "api",
+						DeliverPrefix: "deliver",
+					},
+					Domain: "",
+				}},
+				Sealed:      false,
+				DenyDelete:  true,
+				DenyPurge:   true,
+				AllowRollup: true,
+				Compression: jetstream.S2Compression,
+				FirstSeq:    42,
+				SubjectTransform: &jetstream.SubjectTransformConfig{
+					Source:      "transform-source",
+					Destination: "transform-dest",
+				},
+				RePublish: &jetstream.RePublish{
+					Source:      "re-publish-source",
+					Destination: "re-publish-dest",
+					HeadersOnly: true,
+				},
+				AllowDirect:    true,
+				MirrorDirect:   false,
+				ConsumerLimits: jetstream.StreamConsumerLimits{},
+				Metadata: map[string]string{
+					"meta": "data",
+				},
+				Template: "",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			got, err := mapSpecToConfig(tt.spec)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("mapSpecToConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			// Compare nested structs
+			assert.EqualValues(tt.want, got)
+			//if !reflect.DeepEqual(got, tt.want) {
+			//	t.Errorf("mapSpecToConfig() \ngot  = %v\nwant = %v", got, tt.want)
+			//}
+		})
+	}
+}

--- a/internal/controller/stream_controller_test.go
+++ b/internal/controller/stream_controller_test.go
@@ -283,6 +283,38 @@ var _ = Describe("Stream Controller", func() {
 			Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 		})
 
+		It("should succeed deleting stream resource where the underlying stream was already deleted", func(ctx SpecContext) {
+
+			By("Reconciling the created resource once to ensure the finalizer is set and stream created")
+			controllerReconciler := &StreamReconciler{
+				baseController,
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Deleting the managed stream")
+			err = jsClient.DeleteStream(ctx, streamName)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Marking the resource as deleted")
+			Expect(k8sClient.Delete(ctx, stream)).To(Succeed())
+
+			By("Reconciling the deleted resource")
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking if the resource was removed")
+			Eventually(func() error {
+				found := &api.Stream{}
+				return k8sClient.Get(ctx, typeNamespacedName, found)
+			}, 5*time.Second, time.Second).ShouldNot(Succeed())
+		})
+
 		When("PreventDelete is set", func() {
 			It("should not delete stream marked for deletion", func(ctx SpecContext) {
 

--- a/internal/controller/stream_controller_test.go
+++ b/internal/controller/stream_controller_test.go
@@ -87,10 +87,7 @@ var _ = Describe("Stream Controller", func() {
 		It("should successfully create the stream", func(ctx SpecContext) {
 			By("Reconciling the created resource")
 			controllerReconciler := &StreamReconciler{
-				Client:    k8sClient,
-				Scheme:    k8sClient.Scheme(),
-				Config:    &Config{},
-				JetStream: jsClient,
+				baseController,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -145,10 +142,7 @@ var _ = Describe("Stream Controller", func() {
 
 			By("Reconciling the created resource")
 			controllerReconciler := &StreamReconciler{
-				Client:    k8sClient,
-				Scheme:    k8sClient.Scheme(),
-				Config:    &Config{},
-				JetStream: jsClient,
+				baseController,
 			}
 
 			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -190,10 +184,7 @@ var _ = Describe("Stream Controller", func() {
 		It("should not fail on not existing resource", func(ctx SpecContext) {
 			By("Reconciling the created resource")
 			controllerReconciler := &StreamReconciler{
-				Client:    k8sClient,
-				Scheme:    k8sClient.Scheme(),
-				Config:    &Config{},
-				JetStream: jsClient,
+				baseController,
 			}
 
 			result, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -211,18 +202,13 @@ var _ = Describe("Stream Controller", func() {
 
 			// Setup client for not running server
 			sv := CreateTestServer()
-			js, err := CreateJetStreamClient(&NatsConfig{
-				ServerURL: sv.ClientURL(),
-			}, true)
+			// Is there an easier way to create a failing js client?
+			controller, err := NewJSController(k8sClient, &NatsConfig{ServerURL: sv.ClientURL()}, &Config{})
 			Expect(err).NotTo(HaveOccurred())
 			sv.Shutdown()
-			// Is there an easier way to create a failing js client?
 
 			controllerReconciler := &StreamReconciler{
-				Client:    k8sClient,
-				Scheme:    k8sClient.Scheme(),
-				Config:    &Config{},
-				JetStream: js,
+				controller,
 			}
 
 			result, err := controllerReconciler.Reconcile(ctx, reconcile.Request{

--- a/internal/controller/stream_controller_test.go
+++ b/internal/controller/stream_controller_test.go
@@ -732,9 +732,9 @@ func Test_mapSpecToConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
-			got, err := mapSpecToConfig(tt.spec)
+			got, err := streamSpecToConfig(tt.spec)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("mapSpecToConfig() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("streamSpecToConfig() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -47,6 +47,7 @@ var k8sClient client.Client
 var testEnv *envtest.Environment
 var testServer *server.Server
 var jsClient jetstream.JetStream
+var baseController JetStreamController
 
 func TestControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -86,13 +87,11 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping the test server")
 	testServer = CreateTestServer()
-	jsClient, err = CreateJetStreamClient(
-		&NatsConfig{ServerURL: testServer.ClientURL()},
-		true,
-	)
 	Expect(err).NotTo(HaveOccurred())
-	Expect(jsClient).NotTo(BeNil())
 
+	testNatsConfig := &NatsConfig{ServerURL: testServer.ClientURL()}
+	baseController, err = NewJSController(k8sClient, testNatsConfig, &Config{})
+	jsClient, _, err = CreateJetStreamClient(testNatsConfig, true)
 })
 
 var _ = AfterSuite(func() {

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -19,7 +19,6 @@ package controller
 import (
 	"fmt"
 	"github.com/nats-io/nats-server/v2/server"
-	natsserver "github.com/nats-io/nats-server/v2/test"
 	"github.com/nats-io/nats.go/jetstream"
 	"os"
 	"path/filepath"
@@ -105,19 +104,3 @@ var _ = AfterSuite(func() {
 	err = os.RemoveAll(storeDir)
 	Expect(err).NotTo(HaveOccurred())
 })
-
-func CreateTestServer() *server.Server {
-	opts := &natsserver.DefaultTestOptions
-	opts.JetStream = true
-	opts.Port = -1
-	opts.Debug = true
-
-	dir, err := os.MkdirTemp("", "nats-*")
-	Expect(err).NotTo(HaveOccurred())
-	opts.StoreDir = dir
-
-	ns := natsserver.RunServer(opts)
-	Expect(err).NotTo(HaveOccurred())
-
-	return ns
-}

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"github.com/nats-io/nats-server/v2/server"
 	natsserver "github.com/nats-io/nats-server/v2/test"
-	"github.com/nats-io/nats.go/jetstream"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -37,6 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	jetstreamnatsiov1beta2 "github.com/nats-io/nack/pkg/jetstream/apis/jetstream/v1beta2"
+	//+kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -46,7 +46,6 @@ var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
 var testServer *server.Server
-var jsClient jetstream.JetStream
 
 func TestControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -80,19 +79,14 @@ var _ = BeforeSuite(func() {
 	err = jetstreamnatsiov1beta2.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
+	//+kubebuilder:scaffold:scheme
+
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
 	By("bootstrapping the test server")
 	testServer = CreateTestServer()
-	jsClient, err = CreateJetStreamClient(
-		&NatsConfig{ServerURL: testServer.ClientURL()},
-		true,
-	)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(jsClient).NotTo(BeNil())
-
 })
 
 var _ = AfterSuite(func() {

--- a/internal/controller/types.go
+++ b/internal/controller/types.go
@@ -1,0 +1,6 @@
+package controller
+
+const (
+	readyCondType   = "Ready"
+	streamFinalizer = "stream.nats.io/finalizer"
+)


### PR DESCRIPTION
Implements reconciliation of stream resources in the stream controller

Adds a base JetstreamController for nats/jetstream functionality shared between controllers, like initializing a jetStream client for the current call.
Adds test suit using envtest and embedded nats servers.
Fixes tests failing due to missing k8s binaries.
