### PR TITLE
Fix allowDirect option description

### DIFF
--- a/deploy/crds.yml
+++ b/deploy/crds.yml
@@ -225,7 +225,7 @@ spec:
                     type: string
                     description: Messages will be published from this subject to the destination subject.
               allowDirect:
-                description: When true, allow higher performance, direct access to get individual messages.
+                description: If true, and the stream has more than one replica, each replica will respond to direct get requests for individual messages, not only the leader.
                 type: boolean
                 default: false
               mirrorDirect:

--- a/docs/api.md
+++ b/docs/api.md
@@ -90,7 +90,7 @@ Resource Types:
         <td><b>allowDirect</b></td>
         <td>boolean</td>
         <td>
-          When true, allow higher performance, direct access to get individual messages.<br/>
+          If true, and the stream has more than one replica, each replica will respond to direct get requests for individual messages, not only the leader.<br/>
           <br/>
             <i>Default</i>: false<br/>
         </td>


### PR DESCRIPTION
The current `allowDirect` option description is incorrect and suggest that enabling this option is required to use the API that returns messages from the stream directly. This is way different than the description [in NATS server docs](https://docs.nats.io/nats-concepts/jetstream/streams), where it's described as

> If true, and the stream has more than one replica, each replica will respond to direct get requests for individual messages, not only the leader.

I've checked and it is possible to use this API both with `allowDirect` option enabled and disabled, so it seems that description on the NATS docs is correct, and the name of this option is simply very confusing.

I've changed the current description to the one in the NATS documentation.