### PR TITLE
Improve error reporting when controller is not connected

### DIFF
--- a/internal/controller/client.go
+++ b/internal/controller/client.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 
@@ -191,6 +192,10 @@ type Closable interface {
 }
 
 func CreateJSMClient(conn *pooledConnection, pedantic bool) (*jsm.Manager, error) {
+	if !conn.nc.IsConnected() {
+		return nil, errors.New("not connected")
+	}
+
 	major, minor, _, err := versionComponents(conn.nc.ConnectedServerVersion())
 	if err != nil {
 		return nil, fmt.Errorf("parse server version: %w", err)


### PR DESCRIPTION
`nc.ConnectedServerVersion()` would return an empty string and the controller would log

    create jsm client: parse server version: invalid semver

which is quite confusing.