### PR TITLE
Add notifications about unsupported resources in legacy mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,18 @@
 
 ## JetStream Controller
 
-The JetStream controllers allows you to manage [NATS JetStream](https://docs.nats.io/nats-concepts/jetstream) [Streams](https://docs.nats.io/nats-concepts/jetstream/streams), [Consumers](https://docs.nats.io/nats-concepts/jetstream/consumers), [Key/Value Stores](https://docs.nats.io/nats-concepts/jetstream/key-value-store), and [Object Stores](https://docs.nats.io/nats-concepts/jetstream/obj_store) via Kubernetes CRDs.
+The JetStream controllers allows you to manage [NATS JetStream](https://docs.nats.io/nats-concepts/jetstream) resources via Kubernetes CRDs.
+
+### Controller Modes
+
+NACK supports two controller modes with different capabilities:
+
+| Mode | Streams | Consumers | Key/Value | Object Store | Accounts |
+|------|---------|-----------|-----------|--------------|----------|
+| **Legacy (default)** | ✅ | ✅ | ❌ | ❌ | ❌ |
+| **Control-loop** (`--control-loop`) | ✅ | ✅ | ✅ | ✅ | ✅ |
+
+> **Important**: Key/Value stores and Object stores are **only supported in control-loop mode**. If you create KeyValue or ObjectStore resources without enabling control-loop mode, they will not be reconciled.
 
 Resources managed by NACK controllers are expected to _exclusively_ be managed by NACK, and configuration state will be enforced if mutated by an external client.
 
@@ -84,6 +95,7 @@ spec:
   maxDeliver: 20
   ackPolicy: explicit
 ---
+# Note: KeyValue requires control-loop mode to be enabled
 apiVersion: jetstream.nats.io/v1beta2
 kind: KeyValue
 metadata:
@@ -95,6 +107,7 @@ spec:
   maxBytes: 2048
   compression: true
 ---
+# Note: ObjectStore requires control-loop mode to be enabled
 apiVersion: jetstream.nats.io/v1beta2
 kind: ObjectStore
 metadata:

--- a/cmd/jetstream-controller/main.go
+++ b/cmd/jetstream-controller/main.go
@@ -156,6 +156,7 @@ func run() error {
 	})
 
 	klog.Infof("Starting %s v%s...", os.Args[0], Version)
+	klog.Infof("Running in LEGACY mode")
 	if *readOnly {
 		klog.Infof("Running in read-only mode: JetStream state in server will not be changed")
 	}
@@ -222,6 +223,10 @@ func runControlLoop(config *rest.Config, natsCfg *controller.NatsConfig, control
 	}
 
 	klog.Info("starting manager")
+	klog.Infof("Running in CONTROL-LOOP mode")
+	if controllerCfg.ReadOnly {
+		klog.Infof("Running in read-only mode: JetStream state in server will not be changed")
+	}
 	return mgr.Start(ctrl.SetupSignalHandler())
 }
 

--- a/controllers/jetstream/consumer_test.go
+++ b/controllers/jetstream/consumer_test.go
@@ -401,7 +401,7 @@ func TestConsumerSpecToOpts(t *testing.T) {
 				DeliverPolicy: "lastPerSubject",
 			},
 			expected: jsmapi.ConsumerConfig{
-				Durable: "my-consumer",
+				Durable:       "my-consumer",
 				DeliverPolicy: jsmapi.DeliverLastPerSubject,
 			},
 		},

--- a/docs/api.md
+++ b/docs/api.md
@@ -1781,6 +1781,8 @@ The user and password to be used to connect to the NATS Service.
 
 ## KeyValue
 
+> **⚠️ Important**: KeyValue resources require the JetStream controller to be running in **control-loop mode** (`--control-loop` flag). They are not supported in the default legacy mode.
+
 <sup><sup>[↩ Parent](#jetstreamnatsiov1beta2)</sup></sup>
 
 <table>
@@ -2388,6 +2390,8 @@ A client's TLS certs and keys.
 </table>
 
 ## ObjectStore
+
+> **⚠️ Important**: ObjectStore resources require the JetStream controller to be running in **control-loop mode** (`--control-loop` flag). They are not supported in the default legacy mode.
 
 <sup><sup>[↩ Parent](#jetstreamnatsiov1beta2)</sup></sup>
 


### PR DESCRIPTION
Legacy mode does not support KV or Object Store resources. That could lead to confusion and problems. This commit updates both README.md and logging

This also addresses #281 

Signed-off-by: Tomasz Pietrek <tomasz@synadia.com>