### PR TITLE
fix: use resource namespace when caching account details from secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@
 /tools
 /bin
 /.idea
+
+/kubeconfig

--- a/internal/controller/jetstream_controller.go
+++ b/internal/controller/jetstream_controller.go
@@ -185,7 +185,7 @@ func (c *jsController) natsConfigFromOpts(opts api.ConnectionOpts, ns string) (*
 			return nil, err
 		}
 
-		accDir := filepath.Join(c.cacheDir, c.controllerConfig.Namespace, opts.Account)
+		accDir := filepath.Join(c.cacheDir, ns, opts.Account)
 		if err := os.MkdirAll(accDir, 0o755); err != nil {
 			return nil, err
 		}
@@ -274,7 +274,7 @@ func (c *jsController) natsConfigFromOpts(opts api.ConnectionOpts, ns string) (*
 			return nil, err
 		}
 
-		accDir := filepath.Join(c.cacheDir, c.controllerConfig.Namespace, opts.Account)
+		accDir := filepath.Join(c.cacheDir, ns, opts.Account)
 		if err := os.MkdirAll(accDir, 0o755); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
The controlleConfig.Namespace is used to validate if NACK is allowed to manage the namespaces and should only be used when validating. The likely intention of the previous implementation is that the (validated) namespace is used when storing cached secrets.

Fixes: #310