### PR TITLE
Update Claude workflow permissions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,7 +1,11 @@
 name: Claude Code
 
-# GITHUB_TOKEN is neutered — all GitHub API access uses the App token instead.
-permissions: {}
+# GITHUB_TOKEN needs contents:read and actions:read — required by
+# claude-code-action for restoring trusted config files from the base branch.
+# All other GitHub API access uses the App token.
+permissions:
+  contents: read
+  actions: read
 
 on:
   issue_comment:


### PR DESCRIPTION
## Summary
- Update GITHUB_TOKEN permissions from `{}` to `contents: read` + `actions: read`
- Required by claude-code-action for restoring trusted config files from the base branch (security feature added in v1.0.75)
- Matches the pattern used in ConnectEverything/insights and nats-io/nats-server

## Changes
- `permissions: {}` → `permissions: contents: read, actions: read`
- Updated comment to explain why these permissions are needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)