### PR TITLE
[webhook] add validating webhook to reject sibling-conflicting Stream/KV CRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
   - [Creating NATS Resources](#creating-nats-resources)
   - [Getting Started with Accounts](#getting-started-with-accounts)
   - [Local Development](#local-development)
+  - [Sibling-Conflict Admission Webhook](#sibling-conflict-admission-webhook)
 - [NATS Server Config Reloader](#nats-server-config-reloader)
 - [NATS Boot Config](#nats-boot-config)
 
@@ -470,6 +471,53 @@ Build Docker image
 ```sh
 make jetstream-controller-docker ver=1.2.3
 ```
+
+### Sibling-Conflict Admission Webhook
+
+> **Fork-only feature** — not in upstream nats-io/nack.
+
+The jetstream-controller can optionally serve a `ValidatingAdmissionWebhook`
+that rejects creation/update of `Stream` and `KeyValue` CRs whose `spec.name`
+(or `spec.mirror.name`) conflicts with another CR of the same kind in the
+same namespace.
+
+**Why:** during NATS DR drills (or worse, an ArgoCD app drifting to
+`syncPolicy.automated=on` during failback) it is easy to end up with a
+primary CR and a mirror CR pointing at the same on-wire stream — the
+controller then ping-pongs between source-of-truth and mirror config every
+reconcile cycle. The `--mirror-recreate-on-conflict` flag handles the
+steady-state case; this webhook stops the bad CR from being admitted in the
+first place, regardless of how it was created.
+
+**How it works:**
+
+1. On `CREATE`/`UPDATE` of a `Stream`, the webhook lists every other
+   `Stream` in the same namespace and rejects if any sibling has
+   - the same `spec.name`, or
+   - a `spec.mirror.name` equal to self's `spec.name`, or
+   - a `spec.name` equal to self's `spec.mirror.name`
+2. Same logic for `KeyValue`, keyed on `spec.bucket`.
+3. **Override:** if the target namespace has annotation
+   `drp.cicada.io/drill-active=<drillID>`, the webhook allows the request
+   and emits a warning. The `drp-operator` sets this annotation for the
+   duration of a coordinated drill and clears it on completion.
+
+**Enabling:**
+
+```sh
+jetstream-controller \
+  --control-loop \
+  --enable-sibling-webhook \
+  --webhook-port=9443 \
+  --webhook-cert-dir=/tmp/k8s-webhook-server/serving-certs
+```
+
+The deployment + cert-manager `Certificate` + `ValidatingWebhookConfiguration`
+manifests live in `deploy/webhook.yml`. Downstream Helm charts should expose
+a `webhook.enabled` value (default `false`) gating the rendering of those
+manifests.
+
+**Tests:** `go test ./internal/webhook/... -count=1`
 
 ## NATS Server Config Reloader
 

--- a/cmd/jetstream-controller/main.go
+++ b/cmd/jetstream-controller/main.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/nats-io/nack/controllers/jetstream"
 	"github.com/nats-io/nack/internal/controller"
+	"github.com/nats-io/nack/internal/webhook"
 	v1beta2 "github.com/nats-io/nack/pkg/jetstream/apis/jetstream/v1beta2"
 	clientset "github.com/nats-io/nack/pkg/jetstream/generated/clientset/versioned"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -40,6 +41,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	ctrlwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
 var (
@@ -82,6 +84,9 @@ func run() error {
 	controlLoop := flag.Bool("control-loop", false, "Experimental: Run controller with a full reconciliation control loop")
 	controlLoopSyncInterval := flag.Duration("sync-interval", time.Minute, "Interval to perform scheduled reconcile")
 	healthProbeBindAddress := flag.String("health-probe-bind-address", ":8081", "The address the probe endpoint binds to")
+	enableWebhook := flag.Bool("enable-sibling-webhook", false, "Enable the Stream/KeyValue sibling-conflict admission webhook (control-loop mode only)")
+	webhookPort := flag.Int("webhook-port", 9443, "Webhook server bind port")
+	webhookCertDir := flag.String("webhook-cert-dir", "/tmp/k8s-webhook-server/serving-certs", "Webhook server TLS cert directory")
 
 	flag.Parse()
 
@@ -123,6 +128,9 @@ func run() error {
 			CacheDir:               *cacheDir,
 			RequeueInterval:        *controlLoopSyncInterval,
 			HealthProbeBindAddress: *healthProbeBindAddress,
+			EnableSiblingWebhook:   *enableWebhook,
+			WebhookPort:            *webhookPort,
+			WebhookCertDir:         *webhookCertDir,
 		}
 
 		return runControlLoop(config, natsCfg, controllerCfg)
@@ -185,6 +193,13 @@ func runControlLoop(config *rest.Config, natsCfg *controller.NatsConfig, control
 		HealthProbeBindAddress: controllerCfg.HealthProbeBindAddress,
 	}
 
+	if controllerCfg.EnableSiblingWebhook {
+		ctrlOpts.WebhookServer = ctrlwebhook.NewServer(ctrlwebhook.Options{
+			Port:    controllerCfg.WebhookPort,
+			CertDir: controllerCfg.WebhookCertDir,
+		})
+	}
+
 	if controllerCfg.Namespace != "" {
 		ctrlOpts.Cache = cache.Options{
 			DefaultNamespaces: map[string]cache.Config{
@@ -221,6 +236,13 @@ func runControlLoop(config *rest.Config, natsCfg *controller.NatsConfig, control
 	err = controller.RegisterAll(mgr, natsCfg, controllerCfg)
 	if err != nil {
 		return fmt.Errorf("register jetstream controllers: %w", err)
+	}
+
+	if controllerCfg.EnableSiblingWebhook {
+		if err := webhook.SetupWithManager(mgr); err != nil {
+			return fmt.Errorf("register sibling-conflict webhook: %w", err)
+		}
+		klog.Info("sibling-conflict admission webhook enabled")
 	}
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/deploy/rbac.yml
+++ b/deploy/rbac.yml
@@ -26,6 +26,16 @@ rules:
   - get
   - watch
   - list
+# Required by the sibling-conflict admission webhook to read the
+# drp.cicada.io/drill-active annotation on the request's namespace.
+- apiGroups:
+  - ''
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - jetstream.nats.io
   resources:

--- a/deploy/webhook.yml
+++ b/deploy/webhook.yml
@@ -1,0 +1,105 @@
+# Sibling-conflict admission webhook for Stream and KeyValue CRs.
+#
+# Rejects creation/update of a Stream or KeyValue CR whose spec.name (or
+# spec.mirror.name) collides with another CR of the same kind in the same
+# namespace, UNLESS the namespace carries
+# `drp.cicada.io/drill-active=<drillID>` (set by drp-operator during a drill).
+#
+# This file is the deploy equivalent of a Helm chart's templates/webhook.yaml.
+# A downstream chart can re-template these manifests with values.yaml gates
+# (e.g. webhook.enabled=false by default; consumer flips it to true).
+#
+# Prereqs:
+#   - cert-manager installed in cluster
+#   - jetstream-controller started with --enable-sibling-webhook=true
+#   - jetstream-controller Service named "jetstream-controller-webhook" on
+#     port 9443 (see Service below)
+#
+# To disable in a chart: skip rendering this entire file (`{{- if
+# .Values.webhook.enabled -}}` wrapper).
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: jetstream-controller-webhook
+  namespace: default
+  labels:
+    app.kubernetes.io/name: jetstream-controller
+    app.kubernetes.io/component: webhook
+spec:
+  selector:
+    app.kubernetes.io/name: jetstream-controller
+  ports:
+    - name: https
+      port: 443
+      targetPort: 9443
+      protocol: TCP
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: jetstream-controller-selfsigned
+  namespace: default
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: jetstream-controller-webhook-cert
+  namespace: default
+spec:
+  secretName: jetstream-controller-webhook-cert
+  dnsNames:
+    - jetstream-controller-webhook.default.svc
+    - jetstream-controller-webhook.default.svc.cluster.local
+  issuerRef:
+    name: jetstream-controller-selfsigned
+    kind: Issuer
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: jetstream-controller-sibling-conflict
+  annotations:
+    # cert-manager injects ca.crt of the Secret above into each webhook's
+    # clientConfig.caBundle. Without this, the apiserver rejects the TLS handshake.
+    cert-manager.io/inject-ca-from: default/jetstream-controller-webhook-cert
+webhooks:
+  - name: streams.sibling-conflict.jetstream.nats.io
+    sideEffects: None
+    admissionReviewVersions: ["v1"]
+    # Fail closed: if the webhook is unreachable, reject the CR. This is the
+    # safe default — the bug we're guarding against (silent reconcile war on
+    # drift) is worse than admission downtime.
+    failurePolicy: Fail
+    timeoutSeconds: 5
+    rules:
+      - apiGroups: ["jetstream.nats.io"]
+        apiVersions: ["v1beta2"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["streams"]
+        scope: Namespaced
+    clientConfig:
+      service:
+        name: jetstream-controller-webhook
+        namespace: default
+        path: /validate-jetstream-nats-io-v1beta2-stream
+        port: 443
+  - name: keyvalues.sibling-conflict.jetstream.nats.io
+    sideEffects: None
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+    timeoutSeconds: 5
+    rules:
+      - apiGroups: ["jetstream.nats.io"]
+        apiVersions: ["v1beta2"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["keyvalues"]
+        scope: Namespaced
+    clientConfig:
+      service:
+        name: jetstream-controller-webhook
+        namespace: default
+        path: /validate-jetstream-nats-io-v1beta2-keyvalue
+        port: 443

--- a/internal/controller/register.go
+++ b/internal/controller/register.go
@@ -18,6 +18,13 @@ type Config struct {
 	RequeueInterval        time.Duration
 	CacheDir               string
 	HealthProbeBindAddress string
+
+	// EnableSiblingWebhook turns on the Stream/KeyValue sibling-conflict
+	// admission webhook (control-loop mode only). When true, WebhookPort
+	// and WebhookCertDir are honored.
+	EnableSiblingWebhook bool
+	WebhookPort          int
+	WebhookCertDir       string
 }
 
 // RegisterAll registers all available jetStream controllers to the manager.

--- a/internal/webhook/setup.go
+++ b/internal/webhook/setup.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"fmt"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	api "github.com/nats-io/nack/pkg/jetstream/apis/jetstream/v1beta2"
+)
+
+// SetupWithManager registers the Stream + KeyValue sibling-conflict validators
+// on mgr's webhook server. The webhook server bind address / certs are
+// configured upstream via ctrl.Options.WebhookServer.
+//
+// Paths:
+//   - /validate-jetstream-nats-io-v1beta2-stream
+//   - /validate-jetstream-nats-io-v1beta2-keyvalue
+//
+// These paths must match the clientConfig.service.path in the
+// ValidatingWebhookConfiguration manifest (see deploy/webhook.yml).
+func SetupWithManager(mgr ctrl.Manager) error {
+	scheme := mgr.GetScheme()
+	srv := mgr.GetWebhookServer()
+	if srv == nil {
+		return fmt.Errorf("manager has no webhook server configured")
+	}
+
+	srv.Register(
+		"/validate-jetstream-nats-io-v1beta2-stream",
+		admission.WithValidator[*api.Stream](scheme, &StreamValidator{Client: mgr.GetClient()}),
+	)
+	srv.Register(
+		"/validate-jetstream-nats-io-v1beta2-keyvalue",
+		admission.WithValidator[*api.KeyValue](scheme, &KeyValueValidator{Client: mgr.GetClient()}),
+	)
+
+	return nil
+}

--- a/internal/webhook/sibling.go
+++ b/internal/webhook/sibling.go
@@ -1,0 +1,261 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package webhook implements admission webhooks for nack CRDs.
+//
+// The SiblingConflict validators reject CREATE/UPDATE of Stream/KeyValue CRs
+// whose spec.name (or spec.mirror.name) collides with another CR of the same
+// kind in the same namespace, UNLESS the namespace carries the drill-active
+// annotation set by drp-operator during a coordinated DR drill.
+//
+// This stops the reconcile war that happens when an out-of-band actor (e.g.
+// an ArgoCD app drifting to autosync during failback) recreates mirror CRs
+// alongside their primaries. The fork already has --mirror-recreate-on-conflict
+// for the steady-state case; this webhook is the admission-time guard so the
+// problem never reaches the controller at all.
+package webhook
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	api "github.com/nats-io/nack/pkg/jetstream/apis/jetstream/v1beta2"
+)
+
+// DrillActiveAnnotation, when set on the target namespace, suppresses the
+// sibling-conflict rejection. The drp-operator sets this for the duration of
+// a drill (value = drillID for audit), then clears it on completion.
+const DrillActiveAnnotation = "drp.cicada.io/drill-active"
+
+// remediationHint is appended to every rejection so operators understand
+// what to do — the most common cause is an ArgoCD app drifting to autosync.
+const remediationHint = "Only the drp-operator may create conflicting CRs during a coordinated drill. " +
+	"If this CR is the wanted state, delete the conflicting sibling first. " +
+	"If you're testing operator code locally, set the '" + DrillActiveAnnotation + "' annotation on the namespace."
+
+// drillActive returns true when the namespace carries the drill-active
+// annotation with a non-empty value. A nil client (unit-test path with a
+// pre-seeded namespace lookup) is treated as no drill.
+func drillActive(ctx context.Context, c ctrlclient.Client, namespace string) (bool, string, error) {
+	ns := &corev1.Namespace{}
+	if err := c.Get(ctx, types.NamespacedName{Name: namespace}, ns); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, "", nil
+		}
+		return false, "", fmt.Errorf("get namespace %q: %w", namespace, err)
+	}
+	v, ok := ns.Annotations[DrillActiveAnnotation]
+	if !ok || v == "" {
+		return false, "", nil
+	}
+	return true, v, nil
+}
+
+// streamSpecName extracts the on-wire stream name a Stream CR resolves to.
+// For a primary it is spec.name; for a mirror it is still spec.name (the
+// local mirror name == the source name by NACK convention).
+func streamSpecName(s *api.Stream) string {
+	return s.Spec.Name
+}
+
+// streamMirrorSource returns the name of the source stream this CR mirrors,
+// or "" when the CR is not a mirror.
+func streamMirrorSource(s *api.Stream) string {
+	if s.Spec.Mirror == nil {
+		return ""
+	}
+	return s.Spec.Mirror.Name
+}
+
+// keyValueSpecName returns the bucket name for a KeyValue CR. KV buckets
+// materialize as KV_<bucket> streams in NATS, but the K8s-level conflict
+// surface is the bucket field itself.
+func keyValueSpecName(kv *api.KeyValue) string {
+	return kv.Spec.Bucket
+}
+
+// findStreamConflict returns the first sibling Stream CR in the same
+// namespace that collides with `self`, OR nil. Collision rules:
+//
+//  1. another CR has the same spec.name and a different metadata.name (the
+//     classic primary-vs-mirror-with-same-on-wire-name)
+//  2. another CR is a mirror whose spec.mirror.name equals self.spec.name
+//     (the exact ArgoCD-drift scenario from 2026-05-24: a freshly synced
+//     mirror CR pointing back at a primary that's already live)
+//  3. self IS a mirror whose spec.mirror.name equals another sibling's
+//     spec.name (symmetric: catches it from the other direction too)
+func findStreamConflict(ctx context.Context, c ctrlclient.Client, self *api.Stream) (*api.Stream, string, error) {
+	list := &api.StreamList{}
+	if err := c.List(ctx, list, ctrlclient.InNamespace(self.Namespace)); err != nil {
+		return nil, "", fmt.Errorf("list streams in %q: %w", self.Namespace, err)
+	}
+
+	selfName := streamSpecName(self)
+	selfMirror := streamMirrorSource(self)
+
+	for i := range list.Items {
+		other := &list.Items[i]
+		if other.Name == self.Name {
+			continue // self
+		}
+
+		otherName := streamSpecName(other)
+		otherMirror := streamMirrorSource(other)
+
+		// rule 1: same on-wire name
+		if selfName != "" && otherName == selfName {
+			return other, fmt.Sprintf("sibling Stream %q already declares spec.name=%q", other.Name, otherName), nil
+		}
+		// rule 2: sibling is a mirror of self's spec.name
+		if selfName != "" && otherMirror == selfName {
+			return other, fmt.Sprintf("sibling Stream %q is a mirror of spec.name=%q", other.Name, selfName), nil
+		}
+		// rule 3: self is a mirror of sibling's spec.name
+		if selfMirror != "" && otherName == selfMirror {
+			return other, fmt.Sprintf("self mirrors %q which is also declared as spec.name by sibling Stream %q", selfMirror, other.Name), nil
+		}
+	}
+	return nil, "", nil
+}
+
+// findKeyValueConflict applies the spec.bucket variant of findStreamConflict.
+// KV mirroring rules are simpler — only bucket-vs-bucket collisions are
+// checked because KV mirrors reuse the same bucket name verbatim.
+func findKeyValueConflict(ctx context.Context, c ctrlclient.Client, self *api.KeyValue) (*api.KeyValue, string, error) {
+	list := &api.KeyValueList{}
+	if err := c.List(ctx, list, ctrlclient.InNamespace(self.Namespace)); err != nil {
+		return nil, "", fmt.Errorf("list keyvalues in %q: %w", self.Namespace, err)
+	}
+
+	selfBucket := keyValueSpecName(self)
+	if selfBucket == "" {
+		return nil, "", nil
+	}
+
+	for i := range list.Items {
+		other := &list.Items[i]
+		if other.Name == self.Name {
+			continue
+		}
+		if keyValueSpecName(other) == selfBucket {
+			return other, fmt.Sprintf("sibling KeyValue %q already declares spec.bucket=%q", other.Name, selfBucket), nil
+		}
+	}
+	return nil, "", nil
+}
+
+// rejectionError formats a sibling-conflict rejection consistently.
+func rejectionError(gvk schema.GroupVersionKind, self, sibling, reason string) error {
+	return fmt.Errorf(
+		"%s %q rejected by sibling-conflict webhook: %s. %s",
+		gvk.Kind, self, reason, remediationHint,
+	)
+}
+
+// StreamValidator implements admission.Validator for Stream CRs.
+type StreamValidator struct {
+	Client ctrlclient.Client
+}
+
+var _ admission.Validator[*api.Stream] = &StreamValidator{}
+
+func (v *StreamValidator) ValidateCreate(ctx context.Context, obj *api.Stream) (admission.Warnings, error) {
+	return v.validate(ctx, obj)
+}
+
+func (v *StreamValidator) ValidateUpdate(ctx context.Context, _ *api.Stream, obj *api.Stream) (admission.Warnings, error) {
+	return v.validate(ctx, obj)
+}
+
+func (v *StreamValidator) ValidateDelete(_ context.Context, _ *api.Stream) (admission.Warnings, error) {
+	return nil, nil
+}
+
+func (v *StreamValidator) validate(ctx context.Context, obj *api.Stream) (admission.Warnings, error) {
+	sibling, reason, err := findStreamConflict(ctx, v.Client, obj)
+	if err != nil {
+		return nil, err
+	}
+	if sibling == nil {
+		return nil, nil
+	}
+
+	active, drillID, err := drillActive(ctx, v.Client, obj.Namespace)
+	if err != nil {
+		return nil, err
+	}
+	if active {
+		return admission.Warnings{
+			fmt.Sprintf("sibling conflict allowed during drill %q: %s", drillID, reason),
+		}, nil
+	}
+
+	return nil, rejectionError(
+		schema.GroupVersionKind{Group: api.SchemeGroupVersion.Group, Version: api.SchemeGroupVersion.Version, Kind: "Stream"},
+		obj.Name, sibling.Name, reason,
+	)
+}
+
+// KeyValueValidator implements admission.Validator for KeyValue CRs.
+type KeyValueValidator struct {
+	Client ctrlclient.Client
+}
+
+var _ admission.Validator[*api.KeyValue] = &KeyValueValidator{}
+
+func (v *KeyValueValidator) ValidateCreate(ctx context.Context, obj *api.KeyValue) (admission.Warnings, error) {
+	return v.validate(ctx, obj)
+}
+
+func (v *KeyValueValidator) ValidateUpdate(ctx context.Context, _ *api.KeyValue, obj *api.KeyValue) (admission.Warnings, error) {
+	return v.validate(ctx, obj)
+}
+
+func (v *KeyValueValidator) ValidateDelete(_ context.Context, _ *api.KeyValue) (admission.Warnings, error) {
+	return nil, nil
+}
+
+func (v *KeyValueValidator) validate(ctx context.Context, obj *api.KeyValue) (admission.Warnings, error) {
+	sibling, reason, err := findKeyValueConflict(ctx, v.Client, obj)
+	if err != nil {
+		return nil, err
+	}
+	if sibling == nil {
+		return nil, nil
+	}
+
+	active, drillID, err := drillActive(ctx, v.Client, obj.Namespace)
+	if err != nil {
+		return nil, err
+	}
+	if active {
+		return admission.Warnings{
+			fmt.Sprintf("sibling conflict allowed during drill %q: %s", drillID, reason),
+		}, nil
+	}
+
+	return nil, rejectionError(
+		schema.GroupVersionKind{Group: api.SchemeGroupVersion.Group, Version: api.SchemeGroupVersion.Version, Kind: "KeyValue"},
+		obj.Name, sibling.Name, reason,
+	)
+}

--- a/internal/webhook/sibling_test.go
+++ b/internal/webhook/sibling_test.go
@@ -1,0 +1,230 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	api "github.com/nats-io/nack/pkg/jetstream/apis/jetstream/v1beta2"
+)
+
+const (
+	testNS = "myns"
+)
+
+// scheme builds a runtime scheme with both core and jetstream types so the
+// fake client can store and list them. Done lazily per-test to avoid global
+// state leak between tests.
+func newScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(s))
+	require.NoError(t, api.AddToScheme(s))
+	return s
+}
+
+// newNamespace builds a corev1.Namespace with the given drill-active value
+// (empty means the annotation is absent).
+func newNamespace(name, drillID string) *corev1.Namespace {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+	}
+	if drillID != "" {
+		ns.Annotations = map[string]string{DrillActiveAnnotation: drillID}
+	}
+	return ns
+}
+
+func newStream(metaName, specName string, mirror *api.StreamSource) *api.Stream {
+	return &api.Stream{
+		ObjectMeta: metav1.ObjectMeta{Name: metaName, Namespace: testNS},
+		Spec:       api.StreamSpec{Name: specName, Mirror: mirror},
+	}
+}
+
+func newKV(metaName, bucket string) *api.KeyValue {
+	return &api.KeyValue{
+		ObjectMeta: metav1.ObjectMeta{Name: metaName, Namespace: testNS},
+		Spec:       api.KeyValueSpec{Bucket: bucket},
+	}
+}
+
+func newFakeClient(t *testing.T, objs ...client.Object) client.Client {
+	t.Helper()
+	return fake.NewClientBuilder().
+		WithScheme(newScheme(t)).
+		WithObjects(objs...).
+		Build()
+}
+
+func TestStreamValidator_NoSibling_Allow(t *testing.T) {
+	c := newFakeClient(t, newNamespace(testNS, ""))
+	v := &StreamValidator{Client: c}
+	self := newStream("orders-primary", "ORDERS", nil)
+	_, err := v.ValidateCreate(context.Background(), self)
+	require.NoError(t, err)
+}
+
+func TestStreamValidator_SiblingSameSpecName_Reject(t *testing.T) {
+	existing := newStream("orders-primary", "ORDERS", nil)
+	c := newFakeClient(t, newNamespace(testNS, ""), existing)
+	v := &StreamValidator{Client: c}
+
+	// new CR also wants spec.name=ORDERS (mirror of itself, classic drift)
+	self := newStream("orders-mirror", "ORDERS", &api.StreamSource{Name: "ORDERS"})
+	_, err := v.ValidateCreate(context.Background(), self)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ORDERS")
+	require.Contains(t, err.Error(), "rejected by sibling-conflict webhook")
+	require.Contains(t, err.Error(), DrillActiveAnnotation)
+}
+
+func TestStreamValidator_SiblingMirrorsSelfSpecName_Reject(t *testing.T) {
+	// Sibling CR is a *mirror* of "ORDERS" (post-drift recreation).
+	mirror := newStream("orders-mirror", "ORDERS-MIRROR", &api.StreamSource{Name: "ORDERS"})
+	c := newFakeClient(t, newNamespace(testNS, ""), mirror)
+	v := &StreamValidator{Client: c}
+
+	// Self is the primary "ORDERS" — sibling's mirror.name == self.name.
+	self := newStream("orders-primary", "ORDERS", nil)
+	_, err := v.ValidateCreate(context.Background(), self)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "mirror")
+	require.Contains(t, err.Error(), "ORDERS")
+}
+
+func TestStreamValidator_SelfMirrorsSiblingSpecName_Reject(t *testing.T) {
+	// Sibling primary already exists.
+	primary := newStream("orders-primary", "ORDERS", nil)
+	c := newFakeClient(t, newNamespace(testNS, ""), primary)
+	v := &StreamValidator{Client: c}
+
+	// Self is a mirror of "ORDERS" — the bug from 2026-05-24 incident.
+	self := newStream("orders-mirror", "ORDERS-MIRROR", &api.StreamSource{Name: "ORDERS"})
+	_, err := v.ValidateCreate(context.Background(), self)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "mirror")
+}
+
+func TestStreamValidator_DrillActive_AllowWithWarning(t *testing.T) {
+	existing := newStream("orders-primary", "ORDERS", nil)
+	c := newFakeClient(t, newNamespace(testNS, "drill-2026-05-24-abc"), existing)
+	v := &StreamValidator{Client: c}
+
+	self := newStream("orders-mirror", "ORDERS", &api.StreamSource{Name: "ORDERS"})
+	warnings, err := v.ValidateCreate(context.Background(), self)
+	require.NoError(t, err)
+	require.NotEmpty(t, warnings, "expected a warning when drill-active overrides the conflict")
+	require.Contains(t, strings.Join(warnings, "\n"), "drill-2026-05-24-abc")
+}
+
+func TestStreamValidator_UpdateSelf_NoFalsePositive(t *testing.T) {
+	// The only CR named "orders-primary" with spec.name=ORDERS — and we're
+	// updating it. The list-and-filter logic must exclude self, otherwise
+	// every UPDATE would self-reject.
+	self := newStream("orders-primary", "ORDERS", nil)
+	c := newFakeClient(t, newNamespace(testNS, ""), self)
+	v := &StreamValidator{Client: c}
+
+	updated := newStream("orders-primary", "ORDERS", nil)
+	updated.Spec.Description = "updated"
+	_, err := v.ValidateUpdate(context.Background(), self, updated)
+	require.NoError(t, err)
+}
+
+func TestStreamValidator_EmptySpecName_NoFalsePositive(t *testing.T) {
+	// Two CRs with spec.name="" should NOT conflict (defensive: empty name
+	// is a different kind of error, surfaced elsewhere).
+	a := newStream("a", "", nil)
+	b := newStream("b", "", nil)
+	c := newFakeClient(t, newNamespace(testNS, ""), a)
+	v := &StreamValidator{Client: c}
+
+	_, err := v.ValidateCreate(context.Background(), b)
+	require.NoError(t, err)
+}
+
+func TestKeyValueValidator_NoSibling_Allow(t *testing.T) {
+	c := newFakeClient(t, newNamespace(testNS, ""))
+	v := &KeyValueValidator{Client: c}
+	self := newKV("config-primary", "CONFIG")
+	_, err := v.ValidateCreate(context.Background(), self)
+	require.NoError(t, err)
+}
+
+func TestKeyValueValidator_SiblingSameBucket_Reject(t *testing.T) {
+	existing := newKV("config-primary", "CONFIG")
+	c := newFakeClient(t, newNamespace(testNS, ""), existing)
+	v := &KeyValueValidator{Client: c}
+
+	self := newKV("config-mirror", "CONFIG")
+	_, err := v.ValidateCreate(context.Background(), self)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "CONFIG")
+}
+
+func TestKeyValueValidator_DrillActive_AllowWithWarning(t *testing.T) {
+	existing := newKV("config-primary", "CONFIG")
+	c := newFakeClient(t, newNamespace(testNS, "drill-xyz"), existing)
+	v := &KeyValueValidator{Client: c}
+
+	self := newKV("config-mirror", "CONFIG")
+	warnings, err := v.ValidateCreate(context.Background(), self)
+	require.NoError(t, err)
+	require.NotEmpty(t, warnings)
+	require.Contains(t, strings.Join(warnings, "\n"), "drill-xyz")
+}
+
+func TestKeyValueValidator_UpdateSelf_NoFalsePositive(t *testing.T) {
+	self := newKV("config-primary", "CONFIG")
+	c := newFakeClient(t, newNamespace(testNS, ""), self)
+	v := &KeyValueValidator{Client: c}
+
+	updated := newKV("config-primary", "CONFIG")
+	updated.Spec.Description = "updated"
+	_, err := v.ValidateUpdate(context.Background(), self, updated)
+	require.NoError(t, err)
+}
+
+func TestStreamValidator_NamespaceLookupNotFound_StillReject(t *testing.T) {
+	// Namespace object missing from cluster (edge case): the conflict
+	// detection still fires because findStreamConflict only depends on
+	// the Stream list; only the override path needs the namespace.
+	existing := newStream("orders-primary", "ORDERS", nil)
+	c := newFakeClient(t, existing) // no namespace object
+	v := &StreamValidator{Client: c}
+
+	self := newStream("orders-mirror", "ORDERS", &api.StreamSource{Name: "ORDERS"})
+	_, err := v.ValidateCreate(context.Background(), self)
+	require.Error(t, err)
+}
+
+func TestStreamValidator_ValidateDelete_AlwaysAllow(t *testing.T) {
+	c := newFakeClient(t, newNamespace(testNS, ""))
+	v := &StreamValidator{Client: c}
+	_, err := v.ValidateDelete(context.Background(), newStream("any", "ANY", nil))
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary

- Adds a `ValidatingAdmissionWebhook` (sibling-conflict) to the jetstream-controller fork that rejects CREATE/UPDATE of `Stream` and `KeyValue` CRs whose `spec.name` (or `spec.mirror.name`) collides with another sibling of the same kind in the same namespace.
- **Override path:** if the target namespace carries the annotation `drp.cicada.io/drill-active=<drillID>` (set by drp-operator during a coordinated drill), the conflict is allowed and a warning is emitted.
- Wired behind a `--enable-sibling-webhook` flag, control-loop mode only. Off by default.

## Incident motivating this change

On 2026-05-24, the `nacks-streams-sync-failback` ArgoCD app drifted to `syncPolicy.automated=on` mid-day and recreated 33 mirror `Stream` CRs alongside their live primaries with the same `spec.name`. The NACK controller then ping-ponged ("Source<->mirror flip detected; force-recreating") every ~30 s. The fork already has `--mirror-recreate-on-conflict` for the steady-state case but no admission-time guard, so a single autosync round broke the data plane.

A `ValidatingAdmissionWebhook` catches the problem at admission time regardless of how the CR was created (manual `kubectl apply`, ArgoCD sync, autosync, helm install, etc.) — exactly the layer needed.

## Webhook logic

**Stream** (rejects if any of):
1. `self.spec.name == sibling.spec.name`
2. `self.spec.name == sibling.spec.mirror.name`
3. `self.spec.mirror.name == sibling.spec.name`

**KeyValue** (rejects if):
- `self.spec.bucket == sibling.spec.bucket`

**Override:** namespace has `drp.cicada.io/drill-active=<drillID>` -> allow + warn.

## Files

| File | LOC | Purpose |
| --- | ---: | --- |
| `internal/webhook/sibling.go` | 245 | core validators + conflict detection |
| `internal/webhook/setup.go` | 51 | `SetupWithManager` registration |
| `internal/webhook/sibling_test.go` | 213 | 13 unit tests (fake-client driven) |
| `deploy/webhook.yml` | 105 | Service + cert-manager Issuer/Certificate + ValidatingWebhookConfiguration |
| `deploy/rbac.yml` | +10 | `get,list,watch` on `namespaces` for annotation lookup |
| `cmd/jetstream-controller/main.go` | +22 | `--enable-sibling-webhook` flag + manager wiring |
| `internal/controller/register.go` | +7 | `Config.EnableSiblingWebhook`/`WebhookPort`/`WebhookCertDir` |
| `README.md` | +48 | new section "Sibling-Conflict Admission Webhook" |

## Tests

```
$ go test ./internal/webhook/... -count=1
ok    github.com/nats-io/nack/internal/webhook   0.685s
```

13 unit tests, all passing:
- no sibling -> allow
- sibling same `spec.name` -> reject (incident reproducer)
- sibling is a mirror of self's `spec.name` -> reject
- self is a mirror of sibling's `spec.name` -> reject
- drill-active annotation present -> allow + warning
- self UPDATE -> no false positive
- empty `spec.name` -> no false positive
- KeyValue: no sibling / same bucket / drill-active / self update
- namespace object missing -> still reject (defensive)
- ValidateDelete -> always allow

`go build ./...` and `go vet ./internal/... ./cmd/jetstream-controller/...` clean.

## Deploy / chart wiring

`deploy/webhook.yml` ships:
- Service `jetstream-controller-webhook` (port 443 -> targetPort 9443)
- cert-manager `Issuer` (self-signed) + `Certificate` (DNS names for the in-cluster service)
- `ValidatingWebhookConfiguration` with `failurePolicy: Fail`, `sideEffects: None`, `admissionReviewVersions: [v1]`, scoped to `streams` and `keyvalues` on CREATE/UPDATE
- `cert-manager.io/inject-ca-from` annotation auto-injects the `caBundle`

Downstream Helm charts should expose a `webhook.enabled` value (default `false`) gating the rendering of `deploy/webhook.yml` and the controller flag.

## Follow-up (NOT in this PR)

The `drp-operator` needs to:
1. Set `drp.cicada.io/drill-active=<drillID>` on each participating namespace at drill start
2. Clear it on drill completion (success OR failure)

Separate PR coming. Until that lands, leave `webhook.enabled=false` in production charts so the admission policy doesn't block legitimate drills.

## Test plan

- [ ] Sanity: deploy to colima-drp with `webhook.enabled=true`, confirm controller pod has both ports listening (9443 + healthz 8081).
- [ ] Negative: `kubectl apply` a duplicate-spec.name `Stream` CR in a namespace WITHOUT the drill-active annotation -> expect 4xx with the rejection message naming the conflicting sibling + remediation hint.
- [ ] Override: annotate the namespace with `drp.cicada.io/drill-active=test` and re-apply -> expect Allowed + warning event.
- [ ] Regression: a single primary `Stream` CR (no sibling) applies cleanly through the webhook with no warnings.
- [ ] envtest follow-up: extend `internal/controller/suite_test.go` with a webhook-server harness once drp-operator wires the annotation lifecycle.