### PR TITLE
#239: Allow TokenFile to be specified for (global) authentication to NATS server

### DIFF
--- a/cmd/jetstream-controller/main.go
+++ b/cmd/jetstream-controller/main.go
@@ -73,6 +73,7 @@ func run() error {
 	cert := flag.String("tlscert", "", "NATS TLS public certificate")
 	key := flag.String("tlskey", "", "NATS TLS private key")
 	ca := flag.String("tlsca", "", "NATS TLS certificate authority chain")
+	tokenFile := flag.String("token-file", "", "File to read an auth_token from")
 	tlsfirst := flag.Bool("tlsfirst", false, "If enabled, forces explicit TLS without waiting for Server INFO")
 	server := flag.String("s", "", "NATS Server URL")
 	crdConnect := flag.Bool("crd-connect", false, "If true, then NATS connections will be made from CRD config, not global config. Ignored if running with control loop, CRD options will always override global config")
@@ -111,6 +112,7 @@ func run() error {
 			Certificate: *cert,
 			Key:         *key,
 			TLSFirst:    *tlsfirst,
+			TokenFile:   *tokenFile,
 		}
 
 		if *ca != "" {

--- a/internal/controller/client.go
+++ b/internal/controller/client.go
@@ -22,6 +22,7 @@ type NatsConfig struct {
 	Credentials string   `json:"credential,omitempty"`
 	NKey        string   `json:"nkey,omitempty"`
 	Token       string   `json:"token,omitempty"`
+	TokenFile   string   `json:"token_file,omitempty"`
 	User        string   `json:"username,omitempty"`
 	Password    string   `json:"password,omitempty"`
 	JsDomain    string   `json:"js_domain,omitempty"`
@@ -80,6 +81,14 @@ func (o *NatsConfig) Hash() (string, error) {
 		fb, err := os.ReadFile(o.Key)
 		if err != nil {
 			return "", fmt.Errorf("error opening key file %s: %v", o.Key, err)
+		}
+		b = append(b, fb...)
+	}
+
+	if o.TokenFile != "" {
+		fb, err := os.ReadFile(o.TokenFile)
+		if err != nil {
+			return "", fmt.Errorf("error opening token file %s: %v", o.TokenFile, err)
 		}
 		b = append(b, fb...)
 	}
@@ -181,7 +190,13 @@ func (o *NatsConfig) buildOptions() ([]nats.Option, error) {
 		opts = append(opts, opt)
 	}
 
-	if o.Token != "" {
+	if o.TokenFile != "" {
+		token, err := os.ReadFile(o.TokenFile)
+		if err != nil {
+			return nil, fmt.Errorf("read token file %s: %w", o.TokenFile, err)
+		}
+		opts = append(opts, nats.Token(string(token)))
+	} else if o.Token != "" {
 		opts = append(opts, nats.Token(o.Token))
 	}
 

--- a/internal/controller/client.go
+++ b/internal/controller/client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/nats-io/jsm.go"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
+	"k8s.io/klog/v2"
 )
 
 type NatsConfig struct {
@@ -134,6 +135,8 @@ func (o *NatsConfig) Overlay(overlay *NatsConfig) {
 		o.Credentials = overlay.Credentials
 	} else if overlay.NKey != "" {
 		o.NKey = overlay.NKey
+	} else if overlay.TokenFile != "" {
+		o.TokenFile = overlay.TokenFile
 	} else if overlay.Token != "" {
 		o.Token = overlay.Token
 	} else if overlay.User != "" && overlay.Password != "" {
@@ -143,7 +146,7 @@ func (o *NatsConfig) Overlay(overlay *NatsConfig) {
 }
 
 func (o *NatsConfig) HasAuth() bool {
-	return o.Credentials != "" || o.NKey != "" || o.Token != "" || (o.User != "" && o.Password != "")
+	return o.Credentials != "" || o.NKey != "" || o.Token != "" || (o.User != "" && o.Password != "" || o.TokenFile != "")
 }
 
 func (o *NatsConfig) UnsetAuth() {
@@ -152,6 +155,7 @@ func (o *NatsConfig) UnsetAuth() {
 	o.User = ""
 	o.Password = ""
 	o.Token = ""
+	o.TokenFile = ""
 }
 
 // buildOptions creates options from the config to be used in nats.Connect.
@@ -191,6 +195,7 @@ func (o *NatsConfig) buildOptions() ([]nats.Option, error) {
 	}
 
 	if o.TokenFile != "" {
+		klog.Infof("reading token from: %v", o.TokenFile)
 		token, err := os.ReadFile(o.TokenFile)
 		if err != nil {
 			return nil, fmt.Errorf("read token file %s: %w", o.TokenFile, err)
@@ -203,6 +208,8 @@ func (o *NatsConfig) buildOptions() ([]nats.Option, error) {
 	if o.User != "" && o.Password != "" {
 		opts = append(opts, nats.UserInfo(o.User, o.Password))
 	}
+
+	klog.Infof("NATS client options: %v", opts)
 
 	return opts, nil
 }


### PR DESCRIPTION
Fixes #239 - Adds a flag -token-file to the server, so you can configure your nats server for authentication with K8S Service Accounts instead of static nkeys. 

