### PR TITLE
Reconcile an unset maxAge to unlimited instead of 1 year

### DIFF
--- a/internal/controller/stream_controller.go
+++ b/internal/controller/stream_controller.go
@@ -323,6 +323,17 @@ func getServerStreamState(jsm *jsm.Manager, stream *api.Stream) (*jsmapi.StreamC
 	return &streamCfg, nil
 }
 
+// parseDurationOrZero parses a CRD duration string, treating an empty value as 0.
+// Mirrors the v1beta1 controller's getDurationFromString so an omitted maxAge
+// reconciles to 0 (unlimited) instead of silently inheriting jsm.DefaultStream's
+// 1-year default or a stale server value. See https://github.com/nats-io/nack/issues/377.
+func parseDurationOrZero(v string) (time.Duration, error) {
+	if v == "" {
+		return 0, nil
+	}
+	return time.ParseDuration(v)
+}
+
 func streamSpecToConfig(spec *api.StreamSpec, currentConfig *jsmapi.StreamConfig) ([]jsm.StreamOption, error) {
 	opts := []jsm.StreamOption{
 		jsm.StreamDescription(spec.Description),
@@ -355,9 +366,11 @@ func streamSpecToConfig(spec *api.StreamSpec, currentConfig *jsmapi.StreamConfig
 		})
 	}
 
-	// maxAge
-	if spec.MaxAge != "" {
-		d, err := time.ParseDuration(spec.MaxAge)
+	// maxAge — empty means unlimited (0). Always emit so an omitted value overrides
+	// jsm.DefaultStream's 1-year default on create and resets a previously-set value
+	// on update (UpdateConfiguration uses serverState as the base). See nats-io/nack#377.
+	{
+		d, err := parseDurationOrZero(spec.MaxAge)
 		if err != nil {
 			return nil, fmt.Errorf("parse max age: %w", err)
 		}

--- a/internal/controller/stream_controller_test.go
+++ b/internal/controller/stream_controller_test.go
@@ -322,6 +322,24 @@ var _ = Describe("Stream Controller", func() {
 			Expect(streamInfo.Created).To(BeTemporally("~", time.Now(), time.Second))
 		})
 
+		It("should create a stream with unlimited maxAge when maxAge is unset", func(ctx SpecContext) {
+			// Regression test for nats-io/nack#377: the resource created in the
+			// suite BeforeEach has no maxAge, so the created stream must come up
+			// with MaxAge 0 (unlimited) rather than inheriting jsm DefaultStream's
+			// 1-year (8760h) MaxAge.
+			By("running Reconcile")
+			result, err := controller.Reconcile(ctx, ctrl.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.IsZero()).To(BeTrue())
+
+			By("checking the created stream has no maxAge limit")
+			natsStream, err := jsClient.Stream(ctx, streamName)
+			Expect(err).NotTo(HaveOccurred())
+			streamInfo, err := natsStream.Info(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(streamInfo.Config.MaxAge).To(BeZero())
+		})
+
 		When("sealed is true", func() {
 			BeforeEach(func(ctx SpecContext) {
 				By("setting sealed to true")
@@ -1270,4 +1288,22 @@ func Test_streamSpecToConfig_togglesOff(t *testing.T) {
 			assert.Falsef(t, c.readField(gotOff), "%s should be false after toggling spec off (was true on server)", c.name)
 		})
 	}
+}
+
+// Test_streamSpecToConfig_maxAgeUnsetResetsToZero verifies that an empty maxAge
+// makes the controller emit an explicit MaxAge(0) option that overrides a non-zero
+// base (jsm.DefaultStream on create / serverState on update) instead of leaving it
+// intact. Regression test for nats-io/nack#377 at the config-mapping layer; the
+// end-to-end create-path behavior is covered by the "unlimited maxAge when maxAge
+// is unset" integration case in the controller suite above.
+func Test_streamSpecToConfig_maxAgeUnsetResetsToZero(t *testing.T) {
+	base := &jsmapi.StreamConfig{MaxAge: 365 * 24 * time.Hour}
+	opts, err := streamSpecToConfig(&api.StreamSpec{Storage: "memory", Retention: "limits"}, base)
+	assert.NoError(t, err)
+
+	out := *base
+	for _, o := range opts {
+		assert.NoError(t, o(&out))
+	}
+	assert.Zerof(t, out.MaxAge, "empty maxAge should reset to 0, base held %v", base.MaxAge)
 }


### PR DESCRIPTION
### Problem

In the controller-runtime Stream controller, `streamSpecToConfig` only appends the
`jsm.MaxAge` option when the CR field is a non-empty string:

```go
if spec.MaxAge != "" {
    ...
    opts = append(opts, jsm.MaxAge(d))
}
```

An option that is never appended cannot set a field, so an empty `maxAge` is left
unmanaged in both paths:

- **Create** goes through `jsm.NewStream` → `NewStreamFromDefault(name, DefaultStream, opts)`,
  and `DefaultStream.MaxAge = 24 * 365h = 8760h`. With no `MaxAge` option to override
  it, a stream created from a CR with empty `maxAge` comes up with a **1-year** MaxAge —
  silently aging out data the user expected to keep.
- **Update** applies opts over `serverState` (the current server config) as the base,
  so an empty `maxAge` keeps whatever the stream already has and can never be cleared
  back to unlimited from the CR.

This contradicts the CRD documentation ("Empty for unlimited"). The v1beta1 controller
did not have this bug: it always emitted the option via `getDurationFromString`, which
parses `""` as `0`.

### Fix

Add a small `parseDurationOrZero` helper (empty string → `0`) and always emit `MaxAge`,
dropping the `!= ""` guard. This mirrors the always-set fix already applied to the
togglable bool fields in #366.

`maxAge` is safe to always-emit: it is freely mutable on update (not in nats-server's
`configUpdateCheck` forbidden-on-update set), and `0` means unlimited with no
server-side normalization, so the emitted value is the value the stream ends up with.

### Why maxAge only

The same skip-when-empty pattern affects three more fields this issue names, but each
has a different server-side story, so this PR is scoped to the one field with a concrete
data-retention harm. It does **not** close #377.

- `duplicateWindow`: the server normalizes a `0` window to the 2m default
  (`StreamDefaultDuplicatesWindow`) on non-mirror streams, so `0` is not "off" and there
  is no create-path harm; only mirror streams keep `0`. Low value on its own.
- `maxMsgsPerSubject` (guarded by `> 0`): the server coerces a `0` numeric limit to `-1`
  (unlimited) — but in pedantic mode it rejects `0` and requires an explicit `-1`. So the
  right emitted value is `-1`, not `0`.
- `subjectDeleteMarkerTtl`: coupled to the one-way `allowMsgTtl` toggle, so resetting it
  warrants its own handling.

I can follow up with a single change covering all three (with the `-1`/pedantic and 2m
caveats handled) if you'd prefer.

### Behavior change

A stream created from a CR with an empty `maxAge` now comes up unlimited instead of at 1
year. That is the CRD's documented intent, so it is a fix, but it is a live behavior
change and belongs in the release notes — including the reverse risk: anyone who
unknowingly relied on the accidental 1-year default to cap stream growth will now get
unbounded retention and should set `maxAge` explicitly.

Existing streams are not retroactively reset on controller upgrade alone: the
converged-gate compares the stored-state annotation against server state while
`ObservedGeneration == Generation`, and the recomputed target config (now carrying
`MaxAge(0)`) is applied on the create path or on an actual update. So a stream stuck at
the 1-year default heals on its next spec-generation bump (any CR edit) or on server
drift; new streams are fixed immediately. Once converged there is no reconcile churn.

### Tests

- **Config-mapping unit test** (`Test_streamSpecToConfig_maxAgeUnsetResetsToZero`): seeds
  a base with `MaxAge = 8760h` (simulating `DefaultStream`/serverState) and asserts an
  empty spec emits `MaxAge(0)` that overrides it.
- **Integration case** (envtest + real nats-server): reconciles a CR with no `maxAge` and
  asserts the created stream reports `MaxAge == 0`, pinning the exact create-path symptom.

Both were mutation-checked: reverting the fix makes each fail with the `8760h0m0s`
symptom.

Refs #377 (deliberately partial — see "Why maxAge only"; does not close the issue).
