### PR TITLE
Reconcile maxMsgsPerSubject instead of skipping it when unset

### DIFF
--- a/internal/controller/stream_controller.go
+++ b/internal/controller/stream_controller.go
@@ -347,10 +347,20 @@ func streamSpecToConfig(spec *api.StreamSpec, currentConfig *jsmapi.StreamConfig
 		opts = append(opts, jsm.WorkQueueRetention())
 	}
 
-	// maxMsgsPerSubject
-	if spec.MaxMsgsPerSubject > 0 {
+	// maxMsgsPerSubject — unset means unlimited, which the server spells -1, not 0.
+	// Always emit the option: on update UpdateConfiguration uses serverState as the
+	// base, so skipping it leaves a previously-set limit in place and the field can
+	// never be reset to unlimited. Emitting -1 rather than 0 also matches how the
+	// other numeric limits are handled and satisfies pedantic mode, which rejects a
+	// 0 ("max_msgs_per_subject must be set to -1") instead of coercing it.
+	// See https://github.com/nats-io/nack/issues/377.
+	{
+		maxMsgsPer := int64(spec.MaxMsgsPerSubject)
+		if maxMsgsPer <= 0 {
+			maxMsgsPer = -1
+		}
 		opts = append(opts, func(o *jsmapi.StreamConfig) error {
-			o.MaxMsgsPer = int64(spec.MaxMsgsPerSubject)
+			o.MaxMsgsPer = maxMsgsPer
 			return nil
 		})
 	}

--- a/internal/controller/stream_controller_test.go
+++ b/internal/controller/stream_controller_test.go
@@ -866,6 +866,8 @@ func Test_mapSpecToConfig(t *testing.T) {
 			spec: &api.StreamSpec{},
 			want: jsmapi.StreamConfig{
 				// Placement will be nil when no current config is provided
+				// An unset maxMsgsPerSubject maps to -1 (unlimited), see nats-io/nack#377
+				MaxMsgsPer: -1,
 			},
 			wantErr: false,
 		},
@@ -1057,6 +1059,8 @@ func Test_mapSpecToConfig(t *testing.T) {
 			},
 			want: jsmapi.StreamConfig{
 				PersistMode: jsmapi.DefaultPersistMode,
+				// An unset maxMsgsPerSubject maps to -1 (unlimited), see nats-io/nack#377
+				MaxMsgsPer: -1,
 			},
 			wantErr: false,
 		},
@@ -1291,6 +1295,46 @@ func Test_streamSpecToConfig_togglesOff(t *testing.T) {
 			gotOff, err := apply(specOff, base)
 			assert.NoError(t, err)
 			assert.Falsef(t, c.readField(gotOff), "%s should be false after toggling spec off (was true on server)", c.name)
+		})
+	}
+}
+
+// Test_streamSpecToConfig_maxMsgsPerSubject verifies that an unset
+// maxMsgsPerSubject emits an explicit -1 (unlimited) that overrides a limit already
+// present on the server, rather than being skipped and leaving it intact. On create
+// jsm.DefaultStream already supplies -1, so the gap is on the update path, where
+// UpdateConfiguration uses the live server config as its base. Emitting -1 rather
+// than 0 also keeps pedantic mode happy, since the server rejects a 0 there.
+// Regression test for nats-io/nack#377.
+func Test_streamSpecToConfig_maxMsgsPerSubject(t *testing.T) {
+	tests := []struct {
+		name string
+		spec int
+		base int64
+		want int64
+	}{
+		{name: "unset resets a server-side limit to unlimited", spec: 0, base: 10_000, want: -1},
+		{name: "explicit -1 stays unlimited", spec: -1, base: 10_000, want: -1},
+		{name: "explicit value is applied over the base", spec: 500, base: 10_000, want: 500},
+		{name: "explicit value is applied over an unlimited base", spec: 500, base: -1, want: 500},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			base := &jsmapi.StreamConfig{MaxMsgsPer: test.base}
+			opts, err := streamSpecToConfig(&api.StreamSpec{
+				Storage:           "memory",
+				Retention:         "limits",
+				MaxMsgsPerSubject: test.spec,
+			}, base)
+			assert.NoError(t, err)
+
+			out := *base
+			for _, o := range opts {
+				assert.NoError(t, o(&out))
+			}
+			assert.EqualValuesf(t, test.want, out.MaxMsgsPer,
+				"spec %d over base %d", test.spec, test.base)
 		})
 	}
 }


### PR DESCRIPTION
Picks up one of the three fields left open in #377 after #385 scoped that PR to `maxAge`.

## The defect

`streamSpecToConfig` only appends a `MaxMsgsPer` option when the spec value is `> 0`:

```go
if spec.MaxMsgsPerSubject > 0 {
    opts = append(opts, func(o *jsmapi.StreamConfig) error {
        o.MaxMsgsPer = int64(spec.MaxMsgsPerSubject)
        return nil
    })
}
```

The update path calls `s.UpdateConfiguration(*serverState, opts...)`, which uses the live server config as its base, so an option that is never appended leaves the current value intact. A stream that already carries a per-subject limit therefore cannot be reconciled back to unlimited — **removing `maxMsgsPerSubject` from the resource, or setting it explicitly to `-1`, is silently ignored.** The explicit `-1` case surprised me: it is not just an omitted-value problem, since `-1` is not `> 0` either.

The create path was never affected, because `jsm.DefaultStream` already supplies `MaxMsgsPer: -1`.

## The fix

Always emit the option, using `-1` when the spec value is unset.

`-1` rather than `0` is deliberate, per the guidance in the issue: normal mode's `checkStreamCfg` coerces a `0` to `-1`, but pedantic mode — which the controller enables against nats-server 2.11+ (`CreateJSMClient(conn, true, ...)`) — rejects it with `max_msgs_per_subject must be set to -1`. This also matches how the other numeric limits are already handled.

## Tests

- `Test_streamSpecToConfig_maxMsgsPerSubject`, a table test over the config-mapping layer covering: unset resets a server-side limit to unlimited, an explicit `-1` stays unlimited, and an explicit value is applied over both a limited and an unlimited base. Both "reset" cases fail without the change (they come back as the base `10000`).
- Two existing `Test_mapSpecToConfig` cases (`empty spec`, `persist mode default`) asserted `MaxMsgsPer: 0` for a spec that does not set the field; they now assert `-1`, which is the point of the change.

`make test` passes (all 87 specs in the controller suite, plus the `controllers/jetstream` and `pkg/natsreloader` packages).

The remaining two fields from #377, `duplicateWindow` and `subjectDeleteMarkerTtl`, are untouched here — both need different handling than a plain always-emit, so they are better off in their own change.