### PR TITLE
fix: add validation for NATS credentials data

### DIFF
--- a/controllers/jetstream/consumer.go
+++ b/controllers/jetstream/consumer.go
@@ -46,11 +46,6 @@ func (c *Controller) processConsumerObject(cns *apis.Consumer, jsm jsmClientFunc
 	spec := cns.Spec
 	ifc := c.ji.Consumers(ns)
 
-	acc, err := c.getAccountOverrides(spec.Account, ns)
-	if err != nil {
-		return err
-	}
-
 	defer func() {
 		if err == nil {
 			return
@@ -60,6 +55,11 @@ func (c *Controller) processConsumerObject(cns *apis.Consumer, jsm jsmClientFunc
 			err = fmt.Errorf("%s: %w", err, serr)
 		}
 	}()
+
+	acc, err := c.getAccountOverrides(spec.Account, ns)
+	if err != nil {
+		return err
+	}
 
 	type operator func(ctx context.Context, c jsmClient, spec apis.ConsumerSpec) (err error)
 

--- a/controllers/jetstream/controller.go
+++ b/controllers/jetstream/controller.go
@@ -14,6 +14,7 @@
 package jetstream
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -552,65 +553,136 @@ func (c *Controller) getAccountOverrides(account string, ns string) (*accountOve
 	}
 
 	// Lookup the UserCredentials.
-	if acc.Spec.Creds != nil && acc.Spec.Creds.Secret != nil {
-		secretName := acc.Spec.Creds.Secret.Name
-		secret, err := c.ki.Secrets(ns).Get(c.ctx, secretName, k8smeta.GetOptions{})
-		if err != nil {
-			return nil, err
-		}
+	if acc.Spec.Creds != nil {
+		if acc.Spec.Creds.Secret == nil {
+			if acc.Spec.Creds.File == "" {
+				return nil, fmt.Errorf("account %q credentials file is empty", account)
+			}
+			overrides.userCreds = acc.Spec.Creds.File
+		} else {
+			secretName := acc.Spec.Creds.Secret.Name
+			if secretName == "" {
+				return nil, fmt.Errorf("account %q credentials secret name is empty", account)
+			}
+			credsKey := acc.Spec.Creds.File
+			if credsKey == "" {
+				return nil, fmt.Errorf("account %q credentials key is empty", account)
+			}
 
-		// Write the user credentials to the cache dir.
-		accDir := filepath.Join(c.cacheDir, ns, account)
-		if err := os.MkdirAll(accDir, 0o755); err != nil {
-			return nil, err
-		}
+			secret, err := c.ki.Secrets(ns).Get(c.ctx, secretName, k8smeta.GetOptions{})
+			if err != nil {
+				return nil, err
+			}
+			credsBytes, ok := secret.Data[credsKey]
+			if !ok {
+				return nil, fmt.Errorf("account %q credentials key %q not found in secret %q", account, credsKey, secretName)
+			}
+			if len(bytes.TrimSpace(credsBytes)) == 0 {
+				return nil, fmt.Errorf("account %q credentials key %q in secret %q is empty", account, credsKey, secretName)
+			}
 
-		if credsBytes, ok := secret.Data[acc.Spec.Creds.File]; ok {
-			overrides.userCreds = filepath.Join(accDir, acc.Spec.Creds.File)
-			if err := os.WriteFile(overrides.userCreds, credsBytes, 0o644); err != nil {
+			// Write the user credentials to the cache dir.
+			accDir := filepath.Join(c.cacheDir, ns, account)
+			if err := os.MkdirAll(accDir, 0o755); err != nil {
+				return nil, err
+			}
+			overrides.userCreds = filepath.Join(accDir, credsKey)
+			if err := os.WriteFile(overrides.userCreds, credsBytes, 0o600); err != nil {
 				return nil, err
 			}
 		}
 	}
 
 	// Lookup the NKey seed.
-	if acc.Spec.NKey != nil && acc.Spec.NKey.Secret != nil {
+	if acc.Spec.NKey != nil {
+		if acc.Spec.NKey.Secret == nil {
+			return nil, fmt.Errorf("account %q nkey secret is required", account)
+		}
 		secretName := acc.Spec.NKey.Secret.Name
+		if secretName == "" {
+			return nil, fmt.Errorf("account %q nkey secret name is empty", account)
+		}
+		seedKey := acc.Spec.NKey.Seed
+		if seedKey == "" {
+			return nil, fmt.Errorf("account %q nkey seed key is empty", account)
+		}
+
 		secret, err := c.ki.Secrets(ns).Get(c.ctx, secretName, k8smeta.GetOptions{})
 		if err != nil {
 			return nil, err
 		}
+		nkeyBytes, ok := secret.Data[seedKey]
+		if !ok {
+			return nil, fmt.Errorf("account %q nkey seed key %q not found in secret %q", account, seedKey, secretName)
+		}
+		if len(bytes.TrimSpace(nkeyBytes)) == 0 {
+			return nil, fmt.Errorf("account %q nkey seed key %q in secret %q is empty", account, seedKey, secretName)
+		}
 
-		if nkeyBytes, ok := secret.Data[acc.Spec.NKey.Seed]; ok {
-			overrides.nkey = string(nkeyBytes)
+		accDir := filepath.Join(c.cacheDir, ns, account)
+		if err := os.MkdirAll(accDir, 0o755); err != nil {
+			return nil, err
+		}
+		overrides.nkey = filepath.Join(accDir, seedKey)
+		if err := os.WriteFile(overrides.nkey, nkeyBytes, 0o600); err != nil {
+			return nil, err
 		}
 	}
 
 	// Lookup the Token.
 	if acc.Spec.Token != nil {
 		secretName := acc.Spec.Token.Secret.Name
+		if secretName == "" {
+			return nil, fmt.Errorf("account %q token secret name is empty", account)
+		}
+		tokenKey := acc.Spec.Token.Token
+		if tokenKey == "" {
+			return nil, fmt.Errorf("account %q token key is empty", account)
+		}
+
 		secret, err := c.ki.Secrets(ns).Get(c.ctx, secretName, k8smeta.GetOptions{})
 		if err != nil {
 			return nil, err
 		}
-
-		if token, ok := secret.Data[acc.Spec.Token.Token]; ok {
-			overrides.token = string(token)
+		token, ok := secret.Data[tokenKey]
+		if !ok {
+			return nil, fmt.Errorf("account %q token key %q not found in secret %q", account, tokenKey, secretName)
 		}
+		if len(token) == 0 {
+			return nil, fmt.Errorf("account %q token key %q in secret %q is empty", account, tokenKey, secretName)
+		}
+		overrides.token = string(token)
 	}
 
 	// Lookup the User.
 	if acc.Spec.User != nil {
 		secretName := acc.Spec.User.Secret.Name
+		if secretName == "" {
+			return nil, fmt.Errorf("account %q user secret name is empty", account)
+		}
+		userKey := acc.Spec.User.User
+		if userKey == "" {
+			return nil, fmt.Errorf("account %q username key is empty", account)
+		}
+		passwordKey := acc.Spec.User.Password
+
 		secret, err := c.ki.Secrets(ns).Get(c.ctx, secretName, k8smeta.GetOptions{})
 		if err != nil {
 			return nil, err
 		}
-
-		userBytes := secret.Data[acc.Spec.User.User]
-		passwordBytes := secret.Data[acc.Spec.User.Password]
-		if userBytes != nil && passwordBytes != nil {
-			overrides.user = string(userBytes)
+		userBytes, ok := secret.Data[userKey]
+		if !ok {
+			return nil, fmt.Errorf("account %q username key %q not found in secret %q", account, userKey, secretName)
+		}
+		if len(userBytes) == 0 {
+			return nil, fmt.Errorf("account %q username key %q in secret %q is empty", account, userKey, secretName)
+		}
+		overrides.user = string(userBytes)
+		if passwordKey != "" {
+			passwordBytes, ok := secret.Data[passwordKey]
+			if !ok {
+				return nil, fmt.Errorf("account %q password key %q not found in secret %q", account, passwordKey, secretName)
+			}
 			overrides.password = string(passwordBytes)
 		}
 	}
@@ -664,7 +736,7 @@ func (c *Controller) runWithJsmc(jsm jsmClientFunc, acc *accountOverrides, spec 
 		natsCtx.Nkey = acc.nkey
 	}
 
-	if acc.user != "" && acc.password != "" {
+	if acc.user != "" {
 		natsCtx.Username = acc.user
 		natsCtx.Password = acc.password
 	} else if acc.token != "" {

--- a/controllers/jetstream/controller_test.go
+++ b/controllers/jetstream/controller_test.go
@@ -9,10 +9,12 @@ import (
 
 	jsmapi "github.com/nats-io/jsm.go/api"
 	apis "github.com/nats-io/nack/pkg/jetstream/apis/jetstream/v1beta2"
+	clientsetfake "github.com/nats-io/nack/pkg/jetstream/generated/clientset/versioned/fake"
 
 	k8sapis "k8s.io/api/core/v1"
 	k8smeta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	k8sclientsetfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/util/workqueue"
 )
 
@@ -23,6 +25,197 @@ func TestMain(m *testing.M) {
 	}
 
 	os.Exit(m.Run())
+}
+
+func TestGetAccountOverridesRejectsInvalidAuth(t *testing.T) {
+	authSecret := &apis.SecretRef{Name: "account-auth"}
+	tests := []struct {
+		name       string
+		spec       apis.AccountSpec
+		secretData map[string][]byte
+		wantErr    string
+	}{
+		{
+			name: "empty credentials",
+			spec: apis.AccountSpec{Creds: &apis.CredsSecret{
+				File:   "user.creds",
+				Secret: authSecret,
+			}},
+			secretData: map[string][]byte{"user.creds": {}},
+			wantErr:    `account "test-account" credentials key "user.creds" in secret "account-auth" is empty`,
+		},
+		{
+			name: "missing nkey seed",
+			spec: apis.AccountSpec{NKey: &apis.NKeySecret{
+				Seed:   "seed",
+				Secret: authSecret,
+			}},
+			secretData: map[string][]byte{},
+			wantErr:    `account "test-account" nkey seed key "seed" not found in secret "account-auth"`,
+		},
+		{
+			name: "empty token",
+			spec: apis.AccountSpec{Token: &apis.TokenSecret{
+				Token:  "token",
+				Secret: *authSecret,
+			}},
+			secretData: map[string][]byte{"token": {}},
+			wantErr:    `account "test-account" token key "token" in secret "account-auth" is empty`,
+		},
+		{
+			name: "missing password",
+			spec: apis.AccountSpec{User: &apis.User{
+				User:     "username",
+				Password: "password",
+				Secret:   *authSecret,
+			}},
+			secretData: map[string][]byte{"username": []byte("user")},
+			wantErr:    `account "test-account" password key "password" not found in secret "account-auth"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			account := &apis.Account{
+				ObjectMeta: k8smeta.ObjectMeta{Name: "test-account", Namespace: "default"},
+				Spec:       tt.spec,
+			}
+			secret := &k8sapis.Secret{
+				ObjectMeta: k8smeta.ObjectMeta{Name: authSecret.Name, Namespace: account.Namespace},
+				Data:       tt.secretData,
+			}
+			controller := &Controller{
+				ctx:      context.Background(),
+				opts:     Options{CRDConnect: true},
+				ji:       clientsetfake.NewSimpleClientset(account).JetstreamV1beta2(),
+				ki:       k8sclientsetfake.NewSimpleClientset(secret).CoreV1(),
+				cacheDir: t.TempDir(),
+			}
+
+			overrides, err := controller.getAccountOverrides(account.Name, account.Namespace)
+
+			if overrides != nil {
+				t.Fatalf("got overrides %v; want nil", overrides)
+			}
+			if err == nil || err.Error() != tt.wantErr {
+				t.Fatalf("got error %v; want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestGetAccountOverridesWritesNKeySeedFile(t *testing.T) {
+	seed := []byte("SUABCDEFGHIJKLMNOP")
+	account := &apis.Account{
+		ObjectMeta: k8smeta.ObjectMeta{Name: "test-account", Namespace: "default"},
+		Spec: apis.AccountSpec{NKey: &apis.NKeySecret{
+			Seed:   "seed",
+			Secret: &apis.SecretRef{Name: "account-auth"},
+		}},
+	}
+	secret := &k8sapis.Secret{
+		ObjectMeta: k8smeta.ObjectMeta{Name: "account-auth", Namespace: account.Namespace},
+		Data:       map[string][]byte{"seed": seed},
+	}
+	controller := &Controller{
+		ctx:      context.Background(),
+		opts:     Options{CRDConnect: true},
+		ji:       clientsetfake.NewSimpleClientset(account).JetstreamV1beta2(),
+		ki:       k8sclientsetfake.NewSimpleClientset(secret).CoreV1(),
+		cacheDir: t.TempDir(),
+	}
+
+	overrides, err := controller.getAccountOverrides(account.Name, account.Namespace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writtenSeed, err := os.ReadFile(overrides.nkey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(writtenSeed) != string(seed) {
+		t.Fatalf("got seed %q; want %q", writtenSeed, seed)
+	}
+	info, err := os.Stat(overrides.nkey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("got nkey mode %o; want 600", info.Mode().Perm())
+	}
+}
+
+func TestGetAccountOverridesAllowsEmptyPassword(t *testing.T) {
+	tests := []struct {
+		name        string
+		passwordKey string
+		secretData  map[string][]byte
+	}{
+		{
+			name:       "omitted password selector",
+			secretData: map[string][]byte{"username": []byte("user")},
+		},
+		{
+			name:        "empty password secret value",
+			passwordKey: "password",
+			secretData:  map[string][]byte{"username": []byte("user"), "password": {}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			account := &apis.Account{
+				ObjectMeta: k8smeta.ObjectMeta{Name: "test-account", Namespace: "default"},
+				Spec: apis.AccountSpec{User: &apis.User{
+					User:     "username",
+					Password: tt.passwordKey,
+					Secret:   apis.SecretRef{Name: "account-auth"},
+				}},
+			}
+			secret := &k8sapis.Secret{
+				ObjectMeta: k8smeta.ObjectMeta{Name: "account-auth", Namespace: account.Namespace},
+				Data:       tt.secretData,
+			}
+			controller := &Controller{
+				ctx:      context.Background(),
+				opts:     Options{CRDConnect: true},
+				ji:       clientsetfake.NewSimpleClientset(account).JetstreamV1beta2(),
+				ki:       k8sclientsetfake.NewSimpleClientset(secret).CoreV1(),
+				cacheDir: t.TempDir(),
+			}
+
+			overrides, err := controller.getAccountOverrides(account.Name, account.Namespace)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if overrides.user != "user" || overrides.password != "" {
+				t.Fatalf("got user/password %q/%q; want user with empty password", overrides.user, overrides.password)
+			}
+		})
+	}
+}
+
+func TestRunWithJsmcAllowsEmptyAccountPassword(t *testing.T) {
+	controller := &Controller{opts: Options{CRDConnect: true}}
+	var got *natsContext
+	jsm := func(ctx *natsContext) (jsmClient, error) {
+		got = ctx
+		return &mockJsmClient{}, nil
+	}
+
+	err := controller.runWithJsmc(
+		jsm,
+		&accountOverrides{user: "user"},
+		&jsmcSpecOverrides{},
+		nil,
+		func(jsmClient) error { return nil },
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Username != "user" || got.Password != "" {
+		t.Fatalf("got user/password %q/%q; want user with empty password", got.Username, got.Password)
+	}
 }
 
 func TestGetStorageType(t *testing.T) {

--- a/controllers/jetstream/stream.go
+++ b/controllers/jetstream/stream.go
@@ -59,11 +59,6 @@ func (c *Controller) processStreamObject(str *apis.Stream, jsm jsmClientFunc) (e
 	ns := str.Namespace
 	readOnly := c.opts.ReadOnly
 
-	acc, err := c.getAccountOverrides(spec.Account, ns)
-	if err != nil {
-		return err
-	}
-
 	defer func() {
 		if err == nil {
 			return
@@ -73,6 +68,11 @@ func (c *Controller) processStreamObject(str *apis.Stream, jsm jsmClientFunc) (e
 			err = fmt.Errorf("%s: %w", err, serr)
 		}
 	}()
+
+	acc, err := c.getAccountOverrides(spec.Account, ns)
+	if err != nil {
+		return err
+	}
 
 	type operator func(ctx context.Context, c jsmClient, spec apis.StreamSpec) (err error)
 

--- a/internal/controller/client.go
+++ b/internal/controller/client.go
@@ -127,14 +127,14 @@ func (o *NatsConfig) Overlay(overlay *NatsConfig) {
 		o.NKey = overlay.NKey
 	} else if overlay.Token != "" {
 		o.Token = overlay.Token
-	} else if overlay.User != "" && overlay.Password != "" {
+	} else if overlay.User != "" {
 		o.User = overlay.User
 		o.Password = overlay.Password
 	}
 }
 
 func (o *NatsConfig) HasAuth() bool {
-	return o.Credentials != "" || o.NKey != "" || o.Token != "" || (o.User != "" && o.Password != "")
+	return o.Credentials != "" || o.NKey != "" || o.Token != "" || o.User != ""
 }
 
 func (o *NatsConfig) UnsetAuth() {
@@ -185,7 +185,7 @@ func (o *NatsConfig) buildOptions() ([]nats.Option, error) {
 		opts = append(opts, nats.Token(o.Token))
 	}
 
-	if o.User != "" && o.Password != "" {
+	if o.User != "" {
 		opts = append(opts, nats.UserInfo(o.User, o.Password))
 	}
 

--- a/internal/controller/jetstream_controller.go
+++ b/internal/controller/jetstream_controller.go
@@ -263,9 +263,17 @@ func (c *jsController) natsConfigFromOpts(opts api.ConnectionOpts, ns string) (*
 
 	if account.Spec.Creds != nil && account.Spec.Creds.Secret != nil {
 		credsSecret := &v1.Secret{}
+		secretName := account.Spec.Creds.Secret.Name
+		if secretName == "" {
+			return nil, fmt.Errorf("account %q credentials secret name is empty", opts.Account)
+		}
+		credsKey := account.Spec.Creds.File
+		if credsKey == "" {
+			return nil, fmt.Errorf("account %q credentials key is empty", opts.Account)
+		}
 		err := c.Get(ctx,
 			types.NamespacedName{
-				Name:      account.Spec.Creds.Secret.Name,
+				Name:      secretName,
 				Namespace: ns,
 			},
 			credsSecret,
@@ -274,39 +282,60 @@ func (c *jsController) natsConfigFromOpts(opts api.ConnectionOpts, ns string) (*
 			return nil, err
 		}
 
+		credsBytes, ok := credsSecret.Data[credsKey]
+		if !ok {
+			return nil, fmt.Errorf("account %q credentials key %q not found in secret %q", opts.Account, credsKey, secretName)
+		}
+		if len(bytes.TrimSpace(credsBytes)) == 0 {
+			return nil, fmt.Errorf("account %q credentials key %q in secret %q is empty", opts.Account, credsKey, secretName)
+		}
+
 		accDir := filepath.Join(c.cacheDir, ns, opts.Account)
 		if err := os.MkdirAll(accDir, 0o755); err != nil {
 			return nil, err
 		}
 
-		if credsBytes, ok := credsSecret.Data[account.Spec.Creds.File]; ok {
-			filePath := filepath.Join(accDir, account.Spec.Creds.File)
-			accountOverlay.Credentials = filePath
+		filePath := filepath.Join(accDir, credsKey)
+		accountOverlay.Credentials = filePath
 
-			writeCreds := true
-			if _, err := os.Stat(filePath); err == nil {
-				fileBytes, err := os.ReadFile(filePath)
-				// Skip disk write if data is unchanged
-				if err == nil && bytes.Equal(fileBytes, credsBytes) {
-					writeCreds = false
-				}
+		writeCreds := true
+		if _, err := os.Stat(filePath); err == nil {
+			fileBytes, err := os.ReadFile(filePath)
+			// Skip disk write if data is unchanged
+			if err == nil && bytes.Equal(fileBytes, credsBytes) {
+				writeCreds = false
 			}
+		}
 
-			if writeCreds {
-				if err := os.WriteFile(filePath, credsBytes, 0o600); err != nil {
-					return nil, err
-				}
+		if writeCreds {
+			if err := os.WriteFile(filePath, credsBytes, 0o600); err != nil {
+				return nil, err
 			}
 		}
 	} else if account.Spec.Creds != nil {
+		if account.Spec.Creds.File == "" {
+			return nil, fmt.Errorf("account %q credentials file is empty", opts.Account)
+		}
 		accountOverlay.Credentials = account.Spec.Creds.File
 	}
 
-	if account.Spec.NKey != nil && account.Spec.NKey.Secret != nil {
+	if account.Spec.NKey != nil {
+		if account.Spec.NKey.Secret == nil {
+			return nil, fmt.Errorf("account %q nkey secret is required", opts.Account)
+		}
+		secretName := account.Spec.NKey.Secret.Name
+		if secretName == "" {
+			return nil, fmt.Errorf("account %q nkey secret name is empty", opts.Account)
+		}
+		seedKey := account.Spec.NKey.Seed
+		if seedKey == "" {
+			return nil, fmt.Errorf("account %q nkey seed key is empty", opts.Account)
+		}
+
 		nkeySecret := &v1.Secret{}
 		err := c.Get(ctx,
 			types.NamespacedName{
-				Name:      account.Spec.NKey.Secret.Name,
+				Name:      secretName,
 				Namespace: ns,
 			},
 			nkeySecret,
@@ -315,36 +344,52 @@ func (c *jsController) natsConfigFromOpts(opts api.ConnectionOpts, ns string) (*
 			return nil, err
 		}
 
+		nkeyBytes, ok := nkeySecret.Data[seedKey]
+		if !ok {
+			return nil, fmt.Errorf("account %q nkey seed key %q not found in secret %q", opts.Account, seedKey, secretName)
+		}
+		if len(bytes.TrimSpace(nkeyBytes)) == 0 {
+			return nil, fmt.Errorf("account %q nkey seed key %q in secret %q is empty", opts.Account, seedKey, secretName)
+		}
+
 		accDir := filepath.Join(c.cacheDir, ns, opts.Account)
 		if err := os.MkdirAll(accDir, 0o755); err != nil {
 			return nil, err
 		}
 
-		if nkeyBytes, ok := nkeySecret.Data[account.Spec.NKey.Seed]; ok {
-			filePath := filepath.Join(accDir, account.Spec.NKey.Seed)
-			accountOverlay.NKey = filePath
+		filePath := filepath.Join(accDir, seedKey)
+		accountOverlay.NKey = filePath
 
-			writeNKey := true
-			if _, err := os.Stat(filePath); err == nil {
-				fileBytes, err := os.ReadFile(filePath)
-				if err == nil && bytes.Equal(fileBytes, nkeyBytes) {
-					writeNKey = false
-				}
+		writeNKey := true
+		if _, err := os.Stat(filePath); err == nil {
+			fileBytes, err := os.ReadFile(filePath)
+			if err == nil && bytes.Equal(fileBytes, nkeyBytes) {
+				writeNKey = false
 			}
+		}
 
-			if writeNKey {
-				if err := os.WriteFile(filePath, nkeyBytes, 0o600); err != nil {
-					return nil, err
-				}
+		if writeNKey {
+			if err := os.WriteFile(filePath, nkeyBytes, 0o600); err != nil {
+				return nil, err
 			}
 		}
 	}
 
 	if account.Spec.User != nil {
+		secretName := account.Spec.User.Secret.Name
+		if secretName == "" {
+			return nil, fmt.Errorf("account %q user secret name is empty", opts.Account)
+		}
+		userKey := account.Spec.User.User
+		if userKey == "" {
+			return nil, fmt.Errorf("account %q username key is empty", opts.Account)
+		}
+		passwordKey := account.Spec.User.Password
+
 		userSecret := &v1.Secret{}
 		err := c.Get(ctx,
 			types.NamespacedName{
-				Name:      account.Spec.User.Secret.Name,
+				Name:      secretName,
 				Namespace: ns,
 			},
 			userSecret,
@@ -353,20 +398,37 @@ func (c *jsController) natsConfigFromOpts(opts api.ConnectionOpts, ns string) (*
 			return nil, err
 		}
 
-		userName := userSecret.Data[account.Spec.User.User]
-		userPassword := userSecret.Data[account.Spec.User.Password]
-
-		if userName != nil && userPassword != nil {
-			accountOverlay.User = string(userName)
+		userName, ok := userSecret.Data[userKey]
+		if !ok {
+			return nil, fmt.Errorf("account %q username key %q not found in secret %q", opts.Account, userKey, secretName)
+		}
+		if len(userName) == 0 {
+			return nil, fmt.Errorf("account %q username key %q in secret %q is empty", opts.Account, userKey, secretName)
+		}
+		accountOverlay.User = string(userName)
+		if passwordKey != "" {
+			userPassword, ok := userSecret.Data[passwordKey]
+			if !ok {
+				return nil, fmt.Errorf("account %q password key %q not found in secret %q", opts.Account, passwordKey, secretName)
+			}
 			accountOverlay.Password = string(userPassword)
 		}
 	}
 
 	if account.Spec.Token != nil {
+		secretName := account.Spec.Token.Secret.Name
+		if secretName == "" {
+			return nil, fmt.Errorf("account %q token secret name is empty", opts.Account)
+		}
+		tokenKey := account.Spec.Token.Token
+		if tokenKey == "" {
+			return nil, fmt.Errorf("account %q token key is empty", opts.Account)
+		}
+
 		tokenSecret := &v1.Secret{}
 		err := c.Get(ctx,
 			types.NamespacedName{
-				Name:      account.Spec.Token.Secret.Name,
+				Name:      secretName,
 				Namespace: ns,
 			},
 			tokenSecret,
@@ -375,9 +437,14 @@ func (c *jsController) natsConfigFromOpts(opts api.ConnectionOpts, ns string) (*
 			return nil, err
 		}
 
-		if token := tokenSecret.Data[account.Spec.Token.Token]; token != nil {
-			accountOverlay.Token = string(token)
+		token, ok := tokenSecret.Data[tokenKey]
+		if !ok {
+			return nil, fmt.Errorf("account %q token key %q not found in secret %q", opts.Account, tokenKey, secretName)
 		}
+		if len(token) == 0 {
+			return nil, fmt.Errorf("account %q token key %q in secret %q is empty", opts.Account, tokenKey, secretName)
+		}
+		accountOverlay.Token = string(token)
 	}
 
 	// Overlay Account Config

--- a/internal/controller/jetstream_controller_test.go
+++ b/internal/controller/jetstream_controller_test.go
@@ -6,8 +6,216 @@ import (
 
 	api "github.com/nats-io/nack/pkg/jetstream/apis/jetstream/v1beta2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+func TestNatsConfigFromOptsRejectsInvalidAccountAuth(t *testing.T) {
+	authSecret := &api.SecretRef{Name: "account-auth"}
+	tests := []struct {
+		name       string
+		spec       api.AccountSpec
+		secretData map[string][]byte
+		wantErr    string
+	}{
+		{
+			name: "missing credentials secret key",
+			spec: api.AccountSpec{Creds: &api.CredsSecret{
+				File:   "user.creds",
+				Secret: authSecret,
+			}},
+			secretData: map[string][]byte{},
+			wantErr:    `account "test-account" credentials key "user.creds" not found in secret "account-auth"`,
+		},
+		{
+			name: "empty credentials secret value",
+			spec: api.AccountSpec{Creds: &api.CredsSecret{
+				File:   "user.creds",
+				Secret: authSecret,
+			}},
+			secretData: map[string][]byte{"user.creds": {}},
+			wantErr:    `account "test-account" credentials key "user.creds" in secret "account-auth" is empty`,
+		},
+		{
+			name: "whitespace-only credentials secret value",
+			spec: api.AccountSpec{Creds: &api.CredsSecret{
+				File:   "user.creds",
+				Secret: authSecret,
+			}},
+			secretData: map[string][]byte{"user.creds": []byte(" \n\t")},
+			wantErr:    `account "test-account" credentials key "user.creds" in secret "account-auth" is empty`,
+		},
+		{
+			name:    "empty credentials file",
+			spec:    api.AccountSpec{Creds: &api.CredsSecret{}},
+			wantErr: `account "test-account" credentials file is empty`,
+		},
+		{
+			name:    "missing nkey secret reference",
+			spec:    api.AccountSpec{NKey: &api.NKeySecret{Seed: "seed"}},
+			wantErr: `account "test-account" nkey secret is required`,
+		},
+		{
+			name: "missing nkey seed key",
+			spec: api.AccountSpec{NKey: &api.NKeySecret{
+				Seed:   "seed",
+				Secret: authSecret,
+			}},
+			secretData: map[string][]byte{},
+			wantErr:    `account "test-account" nkey seed key "seed" not found in secret "account-auth"`,
+		},
+		{
+			name: "empty nkey seed",
+			spec: api.AccountSpec{NKey: &api.NKeySecret{
+				Seed:   "seed",
+				Secret: authSecret,
+			}},
+			secretData: map[string][]byte{"seed": {}},
+			wantErr:    `account "test-account" nkey seed key "seed" in secret "account-auth" is empty`,
+		},
+		{
+			name: "missing token key",
+			spec: api.AccountSpec{Token: &api.TokenSecret{
+				Token:  "token",
+				Secret: *authSecret,
+			}},
+			secretData: map[string][]byte{},
+			wantErr:    `account "test-account" token key "token" not found in secret "account-auth"`,
+		},
+		{
+			name: "empty token",
+			spec: api.AccountSpec{Token: &api.TokenSecret{
+				Token:  "token",
+				Secret: *authSecret,
+			}},
+			secretData: map[string][]byte{"token": {}},
+			wantErr:    `account "test-account" token key "token" in secret "account-auth" is empty`,
+		},
+		{
+			name: "missing username key",
+			spec: api.AccountSpec{User: &api.User{
+				User:     "username",
+				Password: "password",
+				Secret:   *authSecret,
+			}},
+			secretData: map[string][]byte{"password": []byte("password")},
+			wantErr:    `account "test-account" username key "username" not found in secret "account-auth"`,
+		},
+		{
+			name: "empty username",
+			spec: api.AccountSpec{User: &api.User{
+				User:     "username",
+				Password: "password",
+				Secret:   *authSecret,
+			}},
+			secretData: map[string][]byte{"username": {}, "password": []byte("password")},
+			wantErr:    `account "test-account" username key "username" in secret "account-auth" is empty`,
+		},
+		{
+			name: "missing password key",
+			spec: api.AccountSpec{User: &api.User{
+				User:     "username",
+				Password: "password",
+				Secret:   *authSecret,
+			}},
+			secretData: map[string][]byte{"username": []byte("user")},
+			wantErr:    `account "test-account" password key "password" not found in secret "account-auth"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			require.NoError(t, api.AddToScheme(scheme))
+			require.NoError(t, v1.AddToScheme(scheme))
+
+			account := &api.Account{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-account", Namespace: "default"},
+				Spec:       tt.spec,
+			}
+			objects := []client.Object{account}
+			if tt.secretData != nil {
+				objects = append(objects, &v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: authSecret.Name, Namespace: "default"},
+					Data:       tt.secretData,
+				})
+			}
+
+			controller := &jsController{
+				Client:   fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build(),
+				config:   &NatsConfig{Credentials: "global.creds"},
+				cacheDir: t.TempDir(),
+			}
+
+			config, err := controller.natsConfigFromOpts(api.ConnectionOpts{Account: account.Name}, account.Namespace)
+
+			assert.Nil(t, config)
+			assert.EqualError(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestNatsConfigFromOptsAllowsEmptyAccountPassword(t *testing.T) {
+	tests := []struct {
+		name        string
+		passwordKey string
+		secretData  map[string][]byte
+	}{
+		{
+			name:       "omitted password selector",
+			secretData: map[string][]byte{"username": []byte("user")},
+		},
+		{
+			name:        "empty password secret value",
+			passwordKey: "password",
+			secretData:  map[string][]byte{"username": []byte("user"), "password": {}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			require.NoError(t, api.AddToScheme(scheme))
+			require.NoError(t, v1.AddToScheme(scheme))
+
+			account := &api.Account{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-account", Namespace: "default"},
+				Spec: api.AccountSpec{User: &api.User{
+					User:     "username",
+					Password: tt.passwordKey,
+					Secret:   api.SecretRef{Name: "account-auth"},
+				}},
+			}
+			secret := &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "account-auth", Namespace: "default"},
+				Data:       tt.secretData,
+			}
+			controller := &jsController{
+				Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(account, secret).Build(),
+				config: &NatsConfig{
+					ServerURL:   "nats://localhost:4222",
+					Credentials: "global.creds",
+				},
+				cacheDir: t.TempDir(),
+			}
+
+			config, err := controller.natsConfigFromOpts(api.ConnectionOpts{Account: account.Name}, account.Namespace)
+
+			require.NoError(t, err)
+			assert.Empty(t, config.Credentials)
+			assert.Equal(t, "user", config.User)
+			assert.Empty(t, config.Password)
+			assert.True(t, config.HasAuth())
+			options, err := config.buildOptions()
+			require.NoError(t, err)
+			assert.Len(t, options, 1)
+		})
+	}
+}
 
 func Test_updateReadyCondition(t *testing.T) {
 	pastTransition := time.Now().UTC().Add(-time.Hour).Format(time.RFC3339Nano)


### PR DESCRIPTION
There are checks in place for the existence of the referenced secret, but the validation is sparse. The controller needs to return errors when referenced credentials, NKey, token, username, or password keys do not exist; otherwise it will silently try to create a stream on the default account.

I was using the `--control-loop` mode with `Account` entities and initially discovered #261. But the validations are also missing in legacy mode for stream/consumer CRDs.

## Logic changes

NATS allows passwordless authentication, but we need to separate it from misconfiguration. This MR introduces the following logic:

- if `spec.user.password` is omitted, controller assumes passwordless authentication
- if it's not, the password key must exist in the referenced Secret
- however, this key may contain an empty value, making the controller fall back to passwordless authentication

## Control-loop mode changes

Add validation for credentials in the referenced Secret's data. Empty credentials now generate an error (but not empty password, which should still be valid).

Relaxed a check in `HasAuth()` in `client.go`, since empty passwords are allowed.

## Legacy mode

In addition to added validation, the `getAccountOverrides()` call in `consumer.go` and `stream.go` was moved after deferred arror handler (otherwise the new validation failures wouldn't change Stream/Consumer state).

## Testing

- unit tests for this behavior are added
- `make test-e2e` passes
